### PR TITLE
fix: tweak status cmds

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,11 +43,10 @@ func Default() Config {
 		},
 		Commands: Commands{
 			StatusCmds: []string{
-				"date",
-				"systemctl --failed",
-				"nixos-rebuild --no-build-nix list-generations",
-				"uname -a",
 				"uptime",
+				"uname -a",
+				"nixos-rebuild --no-build-nix list-generations",
+				"systemctl --failed",
 				"df -h -x tmpfs -x overlay",
 			},
 		},


### PR DESCRIPTION
uptime already shows system clock
bring up uname and list-generations for kernel version check

Signed-off-by: James Hillyerd <james@hillyerd.com>
