### PR TITLE
Basic operation log impl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
             src = ./.;
 
             # Must be updated if go.mod changes.
-            vendorHash = "sha256-PkB3IRiytsAlGIX2mUPqirgc1HVsztAkaHbEhrFZe0k=";
+            vendorHash = "sha256-FU+oKZIOfoGWONIRq1rL9T2WYK0P2Rq1ZKL6LNE4zpo=";
 
             meta.mainProgram = "labcoat";
           };

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/pelletier/go-toml/v2 v2.2.3
+	go.etcd.io/bbolt v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
+go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=

--- a/internal/runner/run.go
+++ b/internal/runner/run.go
@@ -140,13 +140,6 @@ func (r *Model) Running() bool {
 	return r.state == stateNotStarted || r.state == stateRunning
 }
 
-// Complete is true if in done or failed state.
-func (r *Model) Complete() bool {
-	r.RLock()
-	defer r.RUnlock()
-	return r.state == stateSuccess || r.state == stateFailed
-}
-
 // Successful is true if done, not failed.
 func (r *Model) Successful() bool {
 	r.RLock()
@@ -163,7 +156,11 @@ func (r *Model) Closed() bool {
 
 func (r *Model) waitForOutput() tea.Cmd {
 	return func() tea.Msg {
-		if r.Complete() {
+		r.RLock()
+		complete := r.state == stateSuccess || r.state == stateFailed
+		r.RUnlock()
+
+		if complete {
 			r.Lock()
 			defer r.Unlock()
 			if r.closed {

--- a/internal/runner/run.go
+++ b/internal/runner/run.go
@@ -17,7 +17,7 @@ import (
 const (
 	stateNotStarted = iota
 	stateRunning
-	stateDone
+	stateSuccess
 	stateFailed
 )
 
@@ -144,14 +144,21 @@ func (r *Model) Running() bool {
 func (r *Model) Complete() bool {
 	r.RLock()
 	defer r.RUnlock()
-	return r.state == stateDone || r.state == stateFailed
+	return r.state == stateSuccess || r.state == stateFailed
 }
 
 // Successful is true if done, not failed.
 func (r *Model) Successful() bool {
 	r.RLock()
 	defer r.RUnlock()
-	return r.state == stateDone
+	return r.state == stateSuccess
+}
+
+// Closed if complete and no more output allowed.
+func (r *Model) Closed() bool {
+	r.RLock()
+	defer r.RUnlock()
+	return r.closed
 }
 
 func (r *Model) waitForOutput() tea.Cmd {
@@ -165,7 +172,7 @@ func (r *Model) waitForOutput() tea.Cmd {
 
 			// Render status text and stop waiting for output.
 			r.closed = true
-			s := r.Styles.StatusSuffix.Render("\n[" + stateToString(r.state) + "]")
+			s := r.Styles.StatusSuffix.Render("\n[" + stateToString(r) + "]")
 			_, _ = r.output.Write([]byte(s))
 
 			return nil
@@ -185,11 +192,13 @@ func (r *Model) Init() tea.Cmd {
 
 		slog.Info("running", "cmd", r, "dest", r.dest)
 
-		r.err = r.cmd.Run()
+		// Run blocks until cmd is done running.
+		err := r.cmd.Run()
 
 		r.Lock()
-		if r.err == nil {
-			r.state = stateDone
+		r.err = err
+		if err == nil {
+			r.state = stateSuccess
 		} else {
 			r.state = stateFailed
 		}
@@ -265,20 +274,20 @@ func (r *Model) StateString() string {
 	r.RLock()
 	defer r.RUnlock()
 
-	return stateToString(r.state)
+	return stateToString(r)
 }
 
-func stateToString(state int) string {
-	switch state {
+func stateToString(r *Model) string {
+	switch r.state {
 	case stateNotStarted:
-		return "Not Started"
+		return "not started"
 	case stateRunning:
-		return "Running"
-	case stateDone:
-		return "Done"
+		return "running"
+	case stateSuccess:
+		return "success"
 	case stateFailed:
-		return "Failed"
+		return "failed: " + r.err.Error()
 	}
 
-	return "Unknown"
+	return "unknown"
 }

--- a/internal/runner/script.go
+++ b/internal/runner/script.go
@@ -22,6 +22,7 @@ func escape(cmd string) string {
 	return strings.ReplaceAll(cmd, "\"", "\\\"")
 }
 
+// FormatOutput detects label (header) blocks and formats them with labelFn.
 func FormatOutput(s string, labelFn func(string) string) string {
 	var out string
 

--- a/internal/store/boltdb.go
+++ b/internal/store/boltdb.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	hostLogs = "host-logs"
+)
+
+type BoltDB struct {
+	db *bolt.DB
+}
+
+func NewBoltDB(db *bolt.DB) (*BoltDB, error) {
+	err := db.Update(func(tx *bolt.Tx) error {
+		// Create buckets.
+		_, err := tx.CreateBucketIfNotExists([]byte(hostLogs))
+		if err != nil {
+			return fmt.Errorf("Failed to create %q root bucket: %w", hostLogs, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &BoltDB{db: db}, nil
+}
+
+func (b *BoltDB) WriteHostLog(host string, entry string) error {
+	now := time.Now()
+
+	return b.db.Update(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(hostLogs))
+		if root == nil {
+			return fmt.Errorf("Failed to get %q bucket, was nil", hostLogs)
+		}
+		bucket, err := root.CreateBucketIfNotExists([]byte(host))
+		if err != nil {
+			return fmt.Errorf("Failed to create %q bucket: %w", host, err)
+		}
+
+		return bucket.Put(ttob(now), []byte(entry))
+	})
+}
+
+type HostLogEntry struct {
+	Time  time.Time
+	Entry string
+}
+
+func (b *BoltDB) ReadHostLogs(host string) ([]HostLogEntry, error) {
+	entries := make([]HostLogEntry, 0, 64)
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		entries = entries[:0]
+
+		root := tx.Bucket([]byte(hostLogs))
+		if root == nil {
+			return fmt.Errorf("Failed to get %q bucket, was nil", hostLogs)
+		}
+		bucket := root.Bucket([]byte(host))
+		if bucket == nil {
+			return nil
+		}
+
+		// Append entire bucket to entries.
+		c := bucket.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// TODO expire old log entries
+			entries = append(entries, HostLogEntry{
+				Time:  btot(k),
+				Entry: string(v),
+			})
+		}
+
+		return nil
+	})
+
+	return entries, err
+}
+
+func ttob(t time.Time) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(t.UnixMicro()))
+	return b
+}
+
+func btot(b []byte) time.Time {
+	return time.UnixMicro(int64(binary.BigEndian.Uint64(b)))
+}

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -77,7 +77,8 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	host.deploy.intro = intro
 	host.deploy.contentPanel.SetContent(intro)
 
-	return srunner.Init()
+	logCmd := m.hostLogCmd(host, "NixOS deployment started")
+	return tea.Batch(srunner.Init(), logCmd)
 }
 
 func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -42,7 +42,7 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	}
 
 	onUpdate := func(r *runner.Model) tea.Msg {
-		return hostDeployOutputMsg{host: host, final: r.Complete()}
+		return hostDeployOutputMsg{host: host, final: r.Closed()}
 	}
 
 	// Construct nixos-rebuild command line.

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -46,12 +47,8 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	}
 
 	// Construct nixos-rebuild command line.
-	args := []string{
-		"--flake",
-		".#" + host.name,
-		"--target-host",
-		host.target.DeployUser + "@" + host.target.DeployHost,
-	}
+	targetHost := host.target.DeployUser + "@" + host.target.DeployHost
+	args := []string{"--flake", ".#" + host.name, "--target-host", targetHost}
 	if m.config.Nix.DefaultBuildHost != "" {
 		args = append(args, "--build-host", m.config.Nix.DefaultBuildHost)
 	}
@@ -77,19 +74,27 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	host.deploy.intro = intro
 	host.deploy.contentPanel.SetContent(intro)
 
-	logCmd := m.hostLogCmd(host, "NixOS deployment started")
+	logCmd := m.hostLogCmd(host, fmt.Sprintf("NixOS deployment started, target: %s", targetHost))
 	return tea.Batch(srunner.Init(), logCmd)
 }
 
 func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {
+	var cmd tea.Cmd
+
 	host := msg.host
-	if host.deploy.runner == nil {
+	srunner := host.deploy.runner
+	if srunner == nil {
 		slog.Error("Received hostDeployOutputMsg for host with no runner (bug)", "host", host.name)
 		return nil
 	}
 
-	srunner := host.deploy.runner
-	_, cmd := srunner.Update(nil)
+	if msg.final {
+		// Log completion.
+		cmd = m.hostLogCmd(msg.host, fmt.Sprintf("NixOS deployment finished: %s", srunner.StateString()))
+	} else {
+		// Schedule next update.
+		_, cmd = srunner.Update(nil)
+	}
 
 	// Render and cache output content.
 	panel := &host.deploy.contentPanel

--- a/internal/ui/host_log.go
+++ b/internal/ui/host_log.go
@@ -46,8 +46,9 @@ func (m *Model) handleHostLogUpdatedMsg(msg hostLogUpdatedMsg) tea.Cmd {
 		slog.Error("Failed to read operation log", "err", err, "host", hostName)
 		return nil
 	}
+
 	if len(entries) == 0 {
-		m.contentPanel.SetContent("No log entries for " + hostName)
+		m.contentPanel.SetContent("No operation log entries for " + hostName)
 		return nil
 	}
 

--- a/internal/ui/host_log.go
+++ b/internal/ui/host_log.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+)
+
+type hostLogUpdatedMsg struct {
+	host *hostModel
+}
+
+// Logs host+text to DB, returns a hostLogUpdatedMsg to update UI.
+func (m *Model) hostLogCmd(host *hostModel, text string) tea.Cmd {
+	db := m.db
+
+	return func() tea.Msg {
+		hostName := host.name
+		slog.Debug("Writing op log", "host", hostName, "text", text)
+
+		if err := db.WriteHostLog(hostName, text); err != nil {
+			slog.Error("Failed to write to operation log", "err", err, "host", hostName)
+			return errorFlashMsg{
+				text: fmt.Sprintf("Failed to write to `%s` op log: %s", hostName, err),
+			}
+		}
+
+		return hostLogUpdatedMsg{host}
+	}
+}
+
+func (m *Model) handleHostLogUpdatedMsg(msg hostLogUpdatedMsg) tea.Cmd {
+	if m.selectedHost != msg.host || m.selectedHost.hostTab != hostTabLog {
+		return nil
+	}
+
+	// Load log entries.
+	hostName := msg.host.name
+	slog.Debug("Reading op log", "host", hostName)
+	entries, err := m.db.ReadHostLogs(hostName)
+	if err != nil {
+		slog.Error("Failed to read operation log", "err", err, "host", hostName)
+		return nil
+	}
+	if len(entries) == 0 {
+		m.contentPanel.SetContent("No log entries for " + hostName)
+		return nil
+	}
+
+	// Render log entries.
+	// TODO set size for wrapping
+	table := table.New().
+		Border(lipgloss.HiddenBorder()).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		Wrap(true)
+	for _, e := range entries {
+		table.Row(
+			subtleStyle.Render(e.Time.Format(time.DateTime)),
+			e.Entry,
+		)
+	}
+	m.contentPanel.SetContent(table.String())
+
+	// TODO cache rendered output if no new log entries
+
+	return nil
+}

--- a/internal/ui/host_runcmd.go
+++ b/internal/ui/host_runcmd.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -45,7 +46,7 @@ func (m *Model) handleHostRunCommandMsg(msg hostRunCommandMsg) tea.Cmd {
 	}
 
 	onUpdate := func(r *runner.Model) tea.Msg {
-		return hostRunCommandOutputMsg{host: host, final: r.Complete()}
+		return hostRunCommandOutputMsg{host: host, final: r.Closed()}
 	}
 
 	srunner := runner.NewRemote(m.ctx, onUpdate,
@@ -65,14 +66,22 @@ func (m *Model) handleHostRunCommandMsg(msg hostRunCommandMsg) tea.Cmd {
 }
 
 func (m *Model) handleHostRunCommandOutputMsg(msg hostRunCommandOutputMsg) tea.Cmd {
+	var cmd tea.Cmd
+
 	host := msg.host
-	if host.runCmd.runner == nil {
+	srunner := host.runCmd.runner
+	if srunner == nil {
 		slog.Error("Received hostCmdOutput for host with no runner (bug)", "host", host.name)
 		return nil
 	}
 
-	srunner := host.runCmd.runner
-	_, cmd := srunner.Update(nil)
+	if msg.final {
+		// Log completion.
+		cmd = m.hostLogCmd(msg.host, fmt.Sprintf("Ran `%s`: %s", srunner, srunner.StateString()))
+	} else {
+		// Schedule next update.
+		_, cmd = srunner.Update(nil)
+	}
 
 	// Render and cache output content.
 	output := host.runCmd.intro

--- a/internal/ui/host_status.go
+++ b/internal/ui/host_status.go
@@ -30,7 +30,7 @@ func (m *Model) hostStatusCmd(host *hostModel) tea.Cmd {
 
 	onUpdate := func(r *runner.Model) tea.Msg {
 		// Sent when the runner has new output to display.
-		return hostStatusMsg{hostName: host.name, final: r.Complete()}
+		return hostStatusMsg{hostName: host.name, final: r.Closed()}
 	}
 
 	script := runner.NewScript(m.config.Commands.StatusCmds)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jhillyerd/labcoat/internal/nix"
 	"github.com/jhillyerd/labcoat/internal/npool"
 	"github.com/jhillyerd/labcoat/internal/runner"
+	"github.com/jhillyerd/labcoat/internal/store"
 )
 
 const (
@@ -34,13 +35,15 @@ const (
 	hostTabStatus = iota
 	hostTabDeploy
 	hostTabRunCmd
+	hostTabLog
 )
 
-var hostTabNames = []string{"Host Status", "Deploy", "Run Command"}
+var hostTabNames = []string{"Host Status", "Deploy", "Run Command", "Op Log"}
 
 type Model struct {
 	ctx          context.Context
 	program      *tea.Program
+	db           *store.BoltDB
 	config       config.Config
 	ready        bool // true once screen size is known.
 	viewMode     int  // Current UI mode.
@@ -74,6 +77,9 @@ type hostModel struct {
 		runner       *runner.Model
 		cancel       func()
 	}
+	log struct {
+		contentPanel viewport.Model
+	}
 	runCmd struct {
 		intro        string // Rendered intro text: command, host, etc.
 		contentPanel viewport.Model
@@ -104,7 +110,9 @@ type dim struct {
 	height int
 }
 
-func New(conf config.Config, keys config.KeyMap, flakePath string, hostNames []string) Model {
+func New(
+	conf config.Config, keys config.KeyMap, flakePath string, hostNames []string, db *store.BoltDB,
+) Model {
 	hostList := newHostList(hostNames)
 	hostList.list.KeyMap.CursorUp = keys.Up
 	hostList.list.KeyMap.CursorDown = keys.Down
@@ -119,14 +127,16 @@ func New(conf config.Config, keys config.KeyMap, flakePath string, hostNames []s
 	hosts := make(map[string]*hostModel, len(hostNames))
 	for _, v := range hostNames {
 		hm := &hostModel{name: v}
-		hm.status.contentPanel = newContentPanel(keys)
+		hm.log.contentPanel = newContentPanel(keys)
 		hm.runCmd.contentPanel = newContentPanel(keys)
+		hm.status.contentPanel = newContentPanel(keys)
 		hosts[v] = hm
 	}
 
 	return Model{
 		ctx:       context.Background(),
 		config:    conf,
+		db:        db,
 		viewMode:  viewModeHosts,
 		flakePath: flakePath,
 		hostList:  hostList,
@@ -239,11 +249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if len(letter) != 1 {
 				slog.Debug("Invalid jump letter keypress", "key", msg)
-				return m, func() tea.Msg {
-					return errorFlashMsg{
-						text: "Invalid jump letter key pressed",
-					}
-				}
+				return m, errorFlashCmd("Invalid jump letter key pressed")
 			}
 
 			m.hostList, cmd = m.hostList.Update(jumpToLetterMsg(letter))
@@ -357,26 +363,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case hostChangedMsg:
 		return m, m.handleHostChangedMsg(msg)
 
-	case hostHoverMsg:
-		return m, m.handleHostHoverMsg(msg)
-
-	case hostTargetInfoMsg:
-		return m, m.handleHostTargetInfoMsg(msg)
-
-	case hostStatusMsg:
-		return m, m.handleHostStatusMsg(msg)
-
 	case hostDeployMsg:
 		return m, m.handleHostDeployMsg(msg)
 
 	case hostDeployOutputMsg:
 		return m, m.handleHostDeployOutputMsg(msg)
 
+	case hostHoverMsg:
+		return m, m.handleHostHoverMsg(msg)
+
+	case hostLogUpdatedMsg:
+		return m, m.handleHostLogUpdatedMsg(msg)
+
 	case hostRunCommandMsg:
 		return m, m.handleHostRunCommandMsg(msg)
 
 	case hostRunCommandOutputMsg:
 		return m, m.handleHostRunCommandOutputMsg(msg)
+
+	case hostStatusMsg:
+		return m, m.handleHostStatusMsg(msg)
+
+	case hostTargetInfoMsg:
+		return m, m.handleHostTargetInfoMsg(msg)
 
 	case openPagerMsg:
 		return m, m.handleOpenPagerMsg(msg)
@@ -433,39 +442,49 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleNextTabKey() tea.Cmd {
 	if m.selectedHost != nil {
-		m.setVisibleHostTab(m.selectedHost.hostTab + 1)
+		return m.setVisibleHostTab(m.selectedHost.hostTab + 1)
 	}
 
 	return nil
 }
 
-func (m *Model) setVisibleHostTab(hostTab int) {
+func (m *Model) setVisibleHostTab(hostTab int) tea.Cmd {
 	if m.selectedHost != nil {
 		m.selectedHost.hostTab = hostTab % len(hostTabNames)
-		m.updateContentPanel()
+		return m.updateContentPanel()
 	}
+
+	return nil
 }
 
 // Updates the main contentPanel viewport for current host & tab.
 // Multiple viewports are used to maintain scroll position when switching.
-func (m *Model) updateContentPanel() {
+func (m *Model) updateContentPanel() tea.Cmd {
+	var cmd tea.Cmd
+
 	if m.selectedHost != nil {
 		switch m.selectedHost.hostTab {
-		case hostTabStatus:
-			m.contentPanel = &m.selectedHost.status.contentPanel
+		case hostTabLog:
+			m.contentPanel = &m.selectedHost.log.contentPanel
+			// Force log content update.
+			cmd = func() tea.Msg { return hostLogUpdatedMsg{m.selectedHost} }
 		case hostTabDeploy:
 			m.contentPanel = &m.selectedHost.deploy.contentPanel
 		case hostTabRunCmd:
 			m.contentPanel = &m.selectedHost.runCmd.contentPanel
+		case hostTabStatus:
+			m.contentPanel = &m.selectedHost.status.contentPanel
 		default:
 			slog.Error("Unknown host tab index (bug)", "index", m.selectedHost.hostTab)
-			return
+			return nil
 		}
 
 		m.contentPanel.Width = m.sizes.contentPanel.width
 		m.contentPanel.Height = m.sizes.contentPanel.height
 		m.ready = true
 	}
+
+	return cmd
 }
 
 func (m *Model) handleHostChangedMsg(msg hostChangedMsg) tea.Cmd {
@@ -569,7 +588,7 @@ func (m *Model) handleOpenPagerMsg(_ openPagerMsg) tea.Cmd {
 	f, err := os.CreateTemp("", "*.txt")
 	if err != nil {
 		slog.Error("Failed to create temp file", "err", err)
-		return func() tea.Msg { return errorFlashMsg{text: "Pager: " + err.Error()} }
+		return errorFlashCmd("Pager: %s", err)
 	}
 
 	var withErr error
@@ -583,13 +602,13 @@ func (m *Model) handleOpenPagerMsg(_ openPagerMsg) tea.Cmd {
 
 	})
 	if withErr != nil {
-		return func() tea.Msg { return errorFlashMsg{text: "Pager: " + withErr.Error()} }
+		return errorFlashCmd("Pager: %s", withErr)
 	}
 
 	fname := f.Name()
 	if err := f.Close(); err != nil {
 		slog.Error("Failed to close temp file", "err", err)
-		return func() tea.Msg { return errorFlashMsg{text: "Pager: " + err.Error()} }
+		return errorFlashCmd("Pager: %s", err)
 	}
 
 	// TODO handle pager arguments.
@@ -811,17 +830,14 @@ func calculateSizes(win tea.WindowSizeMsg) layoutSizes {
 	return s
 }
 
+// Confirms we have nix info for the specified host.
 func requireHostTarget(logName string, host *hostModel) (bool, tea.Cmd) {
 	if host == nil {
 		slog.Error(logName + " called with nil host (bug)")
 		return false, nil
 	}
 	if host.target == nil {
-		return false, func() tea.Msg {
-			return errorFlashMsg{
-				text: fmt.Sprintf("Target info for host %q not yet available", host.name),
-			}
-		}
+		return false, errorFlashCmd("Target info for host %q not yet available", host.name)
 	}
 
 	return true, nil
@@ -841,6 +857,16 @@ func (m *Model) withVisibleRunner(fn func(*runner.Model)) {
 
 	if runner != nil {
 		fn(runner)
+	}
+}
+
+func errorFlashCmd(format string, a ...any) tea.Cmd {
+	text := fmt.Sprintf(format, a...)
+
+	return func() tea.Msg {
+		return errorFlashMsg{
+			text: text,
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jhillyerd/labcoat/internal/config"
 	"github.com/jhillyerd/labcoat/internal/nix"
+	"github.com/jhillyerd/labcoat/internal/store"
 	"github.com/jhillyerd/labcoat/internal/ui"
+	bolt "go.etcd.io/bbolt"
 )
 
 func main() {
@@ -67,6 +69,27 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Open database.
+	dbPath := defaultDatabasePath()
+	dbDir := filepath.Dir(dbPath)
+	if _, err := os.Stat(dbPath); err != nil {
+		if err := os.MkdirAll(dbDir, 0700); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+	}
+	db, err := bolt.Open(dbPath, 0600, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	defer db.Close()
+	dbs, err := store.NewBoltDB(db)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
 	// Load host list from flake.
 	flakePath := flag.Arg(0)
 	if flakePath == "" {
@@ -90,7 +113,7 @@ func main() {
 	}
 
 	// Launch UI.
-	p := tea.NewProgram(ui.New(*conf, config.DefaultKeyMap, flakePath, hosts), tea.WithAltScreen())
+	p := tea.NewProgram(ui.New(*conf, config.DefaultKeyMap, flakePath, hosts, dbs), tea.WithAltScreen())
 	go p.Send(p)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -110,4 +133,18 @@ func defaultConfigPath() string {
 	}
 
 	return filepath.Join(configRoot, "labcoat", "config.toml")
+}
+
+func defaultDatabasePath() string {
+	configRoot := os.Getenv("XDG_STATE_HOME")
+	if configRoot == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			fmt.Fprintln(os.Stderr, "Neither $XDG_STATE_HOME or $HOME available")
+			os.Exit(1)
+		}
+		configRoot = filepath.Join(home, ".local", "state")
+	}
+
+	return filepath.Join(configRoot, "labcoat", "db_v1.bolt")
 }


### PR DESCRIPTION
Logs operations performed on each host, which can be viewed on the new `Op Log` tab.  Uses bbolt as the datastore.