### PR TITLE
fix: filter out duplicate hostChangedMsg

### DIFF
--- a/internal/ui/host_list.go
+++ b/internal/ui/host_list.go
@@ -117,6 +117,8 @@ func (m *hostListModel) handleJumpToLetterMsg(msg jumpToLetterMsg) tea.Cmd {
 
 func (m *hostListModel) handleHostChange() tea.Cmd {
 	selected := m.list.SelectedItem()
+
+	// Comparing to previous item is not 100% reliable, this just cuts down on noise.
 	if selected != nil && selected != m.prevItem {
 		m.prevItem = selected
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -489,6 +489,11 @@ func (m *Model) updateContentPanel() tea.Cmd {
 }
 
 func (m *Model) handleHostChangedMsg(msg hostChangedMsg) tea.Cmd {
+	if m.selectedHost != nil && m.selectedHost.name == msg.hostName {
+		slog.Debug("ignoring hostChangedMsg for already selected host", "host", msg.hostName)
+		return nil
+	}
+
 	slog.Debug("hostChanged", "host", msg.hostName)
 
 	m.selectedHost = m.hosts[msg.hostName]


### PR DESCRIPTION
Interface value comparisons can trigger incorrect hostChangedMsg to be sent.

Ignore them if the hostName is unchanged.
