### PR TITLE
fix: rewrite runner async buffer interfaces

### DIFF
--- a/internal/runner/buf.go
+++ b/internal/runner/buf.go
@@ -1,11 +1,15 @@
 package runner
 
-import "sync"
+import (
+	"io"
+	"sync"
+)
 
 type buffer struct {
 	sync.RWMutex
 	buf    []byte
 	notify func() // Called when data is written to this buffer.
+	closed bool   // No more writes accepted when true.
 }
 
 func newBuffer(notify func()) *buffer {
@@ -16,15 +20,27 @@ func newBuffer(notify func()) *buffer {
 
 // Write implements io.Writer.
 func (b *buffer) Write(p []byte) (int, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	if b.closed {
+		return 0, io.ErrClosedPipe
+	}
+
 	n := len(p)
 	if n > 0 {
-		b.Lock()
-		defer b.Unlock()
 		b.buf = append(b.buf, p...)
 		b.notify()
 	}
 
 	return n, nil
+}
+
+// Close prevents further writes.
+func (b *buffer) Close() {
+	b.Lock()
+	defer b.Unlock()
+	b.closed = true
 }
 
 func (b *buffer) String() string {

--- a/internal/runner/run.go
+++ b/internal/runner/run.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -154,34 +155,43 @@ func (r *Model) Closed() bool {
 	return r.closed
 }
 
-func (r *Model) waitForOutput() tea.Cmd {
-	return func() tea.Msg {
+// Async loop that waits for output and injects update messages into the program.
+func (r *Model) waitForOutput(program *tea.Program) {
+	for {
 		r.RLock()
 		complete := r.state == stateSuccess || r.state == stateFailed
 		r.RUnlock()
 
 		if complete {
 			r.Lock()
-			defer r.Unlock()
-			if r.closed {
-				return nil
-			}
 
 			// Render status text and stop waiting for output.
 			r.closed = true
 			s := r.Styles.StatusSuffix.Render("\n[" + stateToString(r) + "]")
 			_, _ = r.output.Write([]byte(s))
+			r.output.Close()
+			close(r.notify)
 
-			return nil
+			r.Unlock()
+
+			// Final update message.
+			program.Send(r.onUpdate(r))
+
+			return
 		}
 
-		<-r.notify
-		return r.onUpdate(r)
+		// Wait for output or 100ms timeout to check for completion.
+		select {
+		case <-r.notify:
+			program.Send(r.onUpdate(r))
+		case <-time.After(100 * time.Millisecond):
+			continue
+		}
 	}
 }
 
 // Init implements tea.Model.
-func (r *Model) Init() tea.Cmd {
+func (r *Model) Init(program *tea.Program) tea.Cmd {
 	cmd := func() tea.Msg {
 		r.Lock()
 		r.state = stateRunning
@@ -204,7 +214,9 @@ func (r *Model) Init() tea.Cmd {
 		return r.onUpdate(r)
 	}
 
-	return tea.Batch(cmd, r.waitForOutput())
+	go r.waitForOutput(program)
+
+	return cmd
 }
 
 // PassEnv copies a parent environment variable for use by the child process.
@@ -223,7 +235,7 @@ func (r *Model) SetEnv(name string, value string) {
 
 // Update implements tea.Model.
 func (r *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
-	return r, r.waitForOutput()
+	return r, nil
 }
 
 // View implements tea.Model.

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -71,7 +71,7 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 
 	logCmd := m.hostLogCmd(host, fmt.Sprintf("NixOS deployment started, target: %s", targetHost))
 	busyCmd := hostListIncrBusyCmd(host.name)
-	return tea.Batch(srunner.Init(), logCmd, busyCmd)
+	return tea.Batch(srunner.Init(m.program), logCmd, busyCmd)
 }
 
 func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {

--- a/internal/ui/host_runcmd.go
+++ b/internal/ui/host_runcmd.go
@@ -63,7 +63,7 @@ func (m *Model) handleHostRunCommandMsg(msg hostRunCommandMsg) tea.Cmd {
 	host.runCmd.contentPanel.SetContent(intro)
 
 	busyCmd := hostListIncrBusyCmd(host.name)
-	return tea.Batch(srunner.Init(), busyCmd)
+	return tea.Batch(srunner.Init(m.program), busyCmd)
 }
 
 func (m *Model) handleHostRunCommandOutputMsg(msg hostRunCommandOutputMsg) tea.Cmd {

--- a/internal/ui/host_status.go
+++ b/internal/ui/host_status.go
@@ -47,7 +47,7 @@ func (m *Model) hostStatusCmd(host *hostModel) tea.Cmd {
 	host.status.intro = intro
 	host.status.contentPanel.SetContent(intro)
 
-	return srunner.Init()
+	return srunner.Init(m.program)
 }
 
 func (m *Model) handleHostStatusMsg(msg hostStatusMsg) tea.Cmd {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -490,11 +490,8 @@ func (m *Model) updateContentPanel() tea.Cmd {
 
 func (m *Model) handleHostChangedMsg(msg hostChangedMsg) tea.Cmd {
 	if m.selectedHost != nil && m.selectedHost.name == msg.hostName {
-		slog.Debug("ignoring hostChangedMsg for already selected host", "host", msg.hostName)
 		return nil
 	}
-
-	slog.Debug("hostChanged", "host", msg.hostName)
 
 	m.selectedHost = m.hosts[msg.hostName]
 	m.updateContentPanel()


### PR DESCRIPTION
Using a go-routine is less complicated than trying to schedule a bunch of
future Update calls, and allows for a single final message.
