### PR TITLE
chore: invert position of host select and status indicators

### DIFF
--- a/internal/ui/host_list.go
+++ b/internal/ui/host_list.go
@@ -226,7 +226,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		selected = "»"
 	}
 
-	line := status + style.Render(selected+item.name)
+	line := style.Render(selected) + status + style.Render(item.name)
 	fmt.Fprint(w, d.itemStyle.MaxWidth(d.maxWidth).Render(line))
 }
 


### PR DESCRIPTION
New order should be more intuitive, while still allowing a quick scan of the
status column.
