### PR TITLE
fix: prevent SSH trust lockup with pre-flight checks (#34)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,10 @@
 
 | # | Item | Rationale |
 |---|------|-----------|
-| 1.1 | **Fix SSH trust lockup (#34)** | UI freeze is a showstopper; needs detection of untrusted hosts and a graceful error dialog instead of blocking on an SSH password prompt. May also need to audit `SSH_AUTH_SOCK` handling. |
+| 1.1 | ~~**Fix SSH trust lockup (#34)**~~ | ✅ Done — SSH pre-flight check with inline diagnostics, in-flight guard, and exec error classification. |
 | 1.2 | **Persist deployment history per host** | Building on the flake fingerprinting from #38, record each deployment (timestamp, fingerprint, success/failure) per host in BoltDB so we can later compare against target state and support rollback.
 | 1.3 | **Ping-based reboot tracking** | Half-finished feature in README checklist. After issuing a reboot, poll with `ping` / `ssh` to detect when the host comes back, then auto-refresh status. |
-| 1.4 | **Better error surfacing** | Extend modal dialogs to cover runner failures, SSH errors, flake parse errors, etc. so the user never needs to check a separate log. |
+| 1.4 | **Better error surfacing** | Extend modal dialogs to cover runner failures, flake parse errors, etc. so the user never needs to check a separate log. (SSH error surfacing done in #34.) |
 
 ## Phase 2 — Deployment Intelligence
 

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// SSHCheckError describes a failure to connect to a remote host via SSH,
+// providing a user-friendly diagnosis and suggested fix.
+type SSHCheckError struct {
+	// Dest is the SSH destination that was checked.
+	Dest string
+	// Message is a short description of the failure.
+	Message string
+	// Suggestion tells the user how to resolve the problem.
+	Suggestion string
+}
+
+func (e *SSHCheckError) Error() string {
+	return e.Message
+}
+
+// CheckSSH attempts a minimal SSH connection to verify that the target host is
+// reachable, the host key is trusted, and authentication succeeds. Returns nil
+// on success, or a *SSHCheckError describing the problem.
+func CheckSSH(ctx context.Context, host string, user string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dest := host
+	if user != "" {
+		dest = user + "@" + host
+	}
+
+	cmd := exec.CommandContext(ctx, "ssh", "-oBatchMode=yes", "-oConnectTimeout=5", dest, "true")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	output := strings.TrimSpace(stderr.String())
+	return classifySSHError(dest, output)
+}
+
+// classifySSHError maps raw SSH error output to a user-friendly SSHCheckError.
+func classifySSHError(dest string, output string) *SSHCheckError {
+	e := &SSHCheckError{Dest: dest}
+
+	switch {
+	case strings.Contains(output, "Host key verification failed"):
+		e.Message = "Host key not trusted"
+		e.Suggestion = fmt.Sprintf(
+			"Run `ssh %s` from a terminal to accept the host key, then retry.", dest)
+
+	case strings.Contains(output, "Permission denied"):
+		e.Message = "SSH authentication failed"
+		e.Suggestion = "Ensure your SSH key is loaded (ssh-add) and authorized on the target."
+
+	case strings.Contains(output, "Connection refused"):
+		e.Message = "Connection refused"
+		e.Suggestion = "Ensure SSH is running on the target host."
+
+	case strings.Contains(output, "Connection timed out"):
+		e.Message = "Connection timed out"
+		e.Suggestion = "Ensure the host is reachable on the network."
+
+	case strings.Contains(output, "No route to host"):
+		e.Message = "No route to host"
+		e.Suggestion = "Ensure the host is reachable on the network."
+
+	case strings.Contains(output, "Could not resolve hostname"):
+		e.Message = "Could not resolve hostname"
+		e.Suggestion = "Check that the hostname is correct and DNS is working."
+
+	default:
+		e.Message = "SSH connection failed"
+		if output != "" {
+			e.Suggestion = output
+		} else {
+			e.Suggestion = "Unknown error connecting via SSH."
+		}
+	}
+
+	return e
+}

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -46,11 +46,12 @@ func CheckSSH(ctx context.Context, host string, user string) error {
 	}
 
 	output := strings.TrimSpace(stderr.String())
-	return classifySSHError(dest, output)
+	return classifySSHError(dest, output, err)
 }
 
 // classifySSHError maps raw SSH error output to a user-friendly SSHCheckError.
-func classifySSHError(dest string, output string) *SSHCheckError {
+// Falls back to execErr when stderr is empty (e.g. ssh not found, context deadline).
+func classifySSHError(dest string, output string, execErr error) *SSHCheckError {
 	e := &SSHCheckError{Dest: dest}
 
 	switch {
@@ -80,11 +81,26 @@ func classifySSHError(dest string, output string) *SSHCheckError {
 		e.Suggestion = "Check that the hostname is correct and DNS is working."
 
 	default:
-		e.Message = "SSH connection failed"
-		if output != "" {
-			e.Suggestion = output
+		// execErr may indicate the ssh binary is missing, context was cancelled, etc.
+		detail := output
+		if detail == "" && execErr != nil {
+			detail = execErr.Error()
+		}
+
+		if strings.Contains(detail, "executable file not found") {
+			e.Message = "SSH command not found"
+			e.Suggestion = "Ensure the `ssh` command is installed and in your PATH."
+		} else if strings.Contains(detail, "context deadline") ||
+			strings.Contains(detail, "signal: killed") {
+			e.Message = "SSH check timed out"
+			e.Suggestion = "The host may be unreachable. Check network connectivity and try again."
 		} else {
-			e.Suggestion = "Unknown error connecting via SSH."
+			e.Message = "SSH connection failed"
+			if detail != "" {
+				e.Suggestion = detail
+			} else {
+				e.Suggestion = "Unknown error connecting via SSH."
+			}
 		}
 	}
 

--- a/internal/runner/ssh_test.go
+++ b/internal/runner/ssh_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 func TestClassifySSHError(t *testing.T) {
 	tcs := map[string]struct {
 		output      string
+		execErr     error
 		wantMessage string
 		wantHasDest bool
 	}{
@@ -20,45 +22,54 @@ func TestClassifySSHError(t *testing.T) {
 		"permission denied": {
 			output:      "Permission denied (publickey).",
 			wantMessage: "SSH authentication failed",
-			wantHasDest: false,
 		},
 		"connection refused": {
 			output:      "ssh: connect to host example.com port 22: Connection refused",
 			wantMessage: "Connection refused",
-			wantHasDest: false,
 		},
 		"connection timed out": {
 			output:      "ssh: connect to host example.com port 22: Connection timed out",
 			wantMessage: "Connection timed out",
-			wantHasDest: false,
 		},
 		"no route": {
 			output:      "ssh: connect to host example.com port 22: No route to host",
 			wantMessage: "No route to host",
-			wantHasDest: false,
 		},
 		"resolve hostname": {
 			output:      "ssh: Could not resolve hostname badhost: Name or service not known",
 			wantMessage: "Could not resolve hostname",
-			wantHasDest: false,
 		},
-		"unknown error": {
+		"unknown error with output": {
 			output:      "something unexpected happened",
 			wantMessage: "SSH connection failed",
-			wantHasDest: false,
 		},
-		"empty error": {
+		"unknown error empty": {
 			output:      "",
+			execErr:     fmt.Errorf("some exec error"),
 			wantMessage: "SSH connection failed",
-			wantHasDest: false,
+		},
+		"ssh not found": {
+			output:      "",
+			execErr:     fmt.Errorf("exec: \"ssh\": executable file not found in $PATH"),
+			wantMessage: "SSH command not found",
+		},
+		"context deadline": {
+			output:      "",
+			execErr:     fmt.Errorf("context deadline exceeded"),
+			wantMessage: "SSH check timed out",
+		},
+		"signal killed": {
+			output:      "",
+			execErr:     fmt.Errorf("signal: killed"),
+			wantMessage: "SSH check timed out",
 		},
 	}
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			err := classifySSHError("user@host", tc.output)
+			err := classifySSHError("user@host", tc.output, tc.execErr)
 			assert.Equal(t, tc.wantMessage, err.Message)
-			assert.NotNil(t, err.Suggestion)
+			assert.NotEmpty(t, err.Suggestion)
 			if tc.wantHasDest {
 				assert.Contains(t, err.Suggestion, "user@host")
 			}
@@ -67,6 +78,14 @@ func TestClassifySSHError(t *testing.T) {
 }
 
 func TestClassifySSHErrorHostKeyContainsDest(t *testing.T) {
-	err := classifySSHError("root@myserver.example.com", "Host key verification failed.")
+	err := classifySSHError("root@myserver.example.com", "Host key verification failed.", nil)
 	assert.Contains(t, err.Suggestion, "root@myserver.example.com")
 }
+
+func TestClassifySSHErrorSSHNotFoundSuggestion(t *testing.T) {
+	err := classifySSHError("user@host", "",
+		fmt.Errorf("exec: \"ssh\": executable file not found in $PATH"))
+	assert.Equal(t, "SSH command not found", err.Message)
+	assert.Contains(t, err.Suggestion, "ssh")
+}
+

--- a/internal/runner/ssh_test.go
+++ b/internal/runner/ssh_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifySSHError(t *testing.T) {
+	tcs := map[string]struct {
+		output      string
+		wantMessage string
+		wantHasDest bool
+	}{
+		"host key": {
+			output:      "Host key verification failed.",
+			wantMessage: "Host key not trusted",
+			wantHasDest: true,
+		},
+		"permission denied": {
+			output:      "Permission denied (publickey).",
+			wantMessage: "SSH authentication failed",
+			wantHasDest: false,
+		},
+		"connection refused": {
+			output:      "ssh: connect to host example.com port 22: Connection refused",
+			wantMessage: "Connection refused",
+			wantHasDest: false,
+		},
+		"connection timed out": {
+			output:      "ssh: connect to host example.com port 22: Connection timed out",
+			wantMessage: "Connection timed out",
+			wantHasDest: false,
+		},
+		"no route": {
+			output:      "ssh: connect to host example.com port 22: No route to host",
+			wantMessage: "No route to host",
+			wantHasDest: false,
+		},
+		"resolve hostname": {
+			output:      "ssh: Could not resolve hostname badhost: Name or service not known",
+			wantMessage: "Could not resolve hostname",
+			wantHasDest: false,
+		},
+		"unknown error": {
+			output:      "something unexpected happened",
+			wantMessage: "SSH connection failed",
+			wantHasDest: false,
+		},
+		"empty error": {
+			output:      "",
+			wantMessage: "SSH connection failed",
+			wantHasDest: false,
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			err := classifySSHError("user@host", tc.output)
+			assert.Equal(t, tc.wantMessage, err.Message)
+			assert.NotNil(t, err.Suggestion)
+			if tc.wantHasDest {
+				assert.Contains(t, err.Suggestion, "user@host")
+			}
+		})
+	}
+}
+
+func TestClassifySSHErrorHostKeyContainsDest(t *testing.T) {
+	err := classifySSHError("root@myserver.example.com", "Host key verification failed.")
+	assert.Contains(t, err.Suggestion, "root@myserver.example.com")
+}

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -58,6 +58,10 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	srunner := runner.NewLocal(ctx, onUpdate, m.flakePath, "nixos-rebuild", args...)
 	srunner.PassEnv("HOME", "PATH", "SSH_AUTH_SOCK", "SSH_TTY")
 
+	// Prevent nixos-rebuild's internal SSH from prompting for host keys or
+	// passwords, which would freeze the TUI. Failures are shown inline.
+	srunner.SetEnv("NIX_SSHOPTS", "-oBatchMode=yes")
+
 	srunner.Styles.StatusSuffix = subtleStyle
 	host.deploy.runner = srunner
 	host.deploy.cancel = cancel

--- a/internal/ui/host_status.go
+++ b/internal/ui/host_status.go
@@ -22,12 +22,12 @@ func (m *Model) hostStatusCmd(host *hostModel) tea.Cmd {
 	m.setVisibleHostTab(hostTabStatus)
 
 	// Run SSH pre-flight check if not yet verified.
-	if !host.sshChecked {
+	if host.sshState == sshCheckNone {
 		return m.hostSSHCheckCmd(host)
 	}
 
 	// If SSH check failed, don't attempt status (user must press `s` to retry).
-	if !host.sshReachable {
+	if host.sshState == sshCheckFailed {
 		slog.Debug("hostStatusCmd: SSH not reachable, skipping", "host", host.name)
 		return nil
 	}

--- a/internal/ui/host_status.go
+++ b/internal/ui/host_status.go
@@ -21,6 +21,17 @@ func (m *Model) hostStatusCmd(host *hostModel) tea.Cmd {
 
 	m.setVisibleHostTab(hostTabStatus)
 
+	// Run SSH pre-flight check if not yet verified.
+	if !host.sshChecked {
+		return m.hostSSHCheckCmd(host)
+	}
+
+	// If SSH check failed, don't attempt status (user must press `s` to retry).
+	if !host.sshReachable {
+		slog.Debug("hostStatusCmd: SSH not reachable, skipping", "host", host.name)
+		return nil
+	}
+
 	// Do nothing if status job is already running.
 	srunner := m.selectedHost.status.runner
 	if srunner != nil && srunner.Running() {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -70,13 +70,20 @@ type Model struct {
 	cmdHistory     []string
 }
 
+type sshCheckState int
+
+const (
+	sshCheckNone    sshCheckState = iota // Not yet attempted.
+	sshCheckPending                      // In-flight.
+	sshCheckPassed                       // Reachable.
+	sshCheckFailed                       // Unreachable; user must retry.
+)
+
 type hostModel struct {
 	name    string
 	target  *nix.TargetInfo // Cached info about target host.
 	hostTab int             // Currently visible host tab.
-	sshChecking  bool       // Whether an SSH pre-flight check is currently in-flight.
-	sshChecked   bool       // Whether SSH connectivity has been verified.
-	sshReachable bool       // Whether the SSH connectivity check passed.
+	sshState sshCheckState // Current state of SSH pre-flight connectivity check.
 	deploy  struct {
 		intro        string // Rendered intro text: command, host, etc.
 		contentPanel viewport.Model
@@ -377,9 +384,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keys.Status):
 			// Reset SSH check to allow re-checking on explicit status request.
-			if m.selectedHost != nil && !m.selectedHost.sshReachable {
-				m.selectedHost.sshChecked = false
-				m.selectedHost.sshChecking = false
+			if m.selectedHost != nil && m.selectedHost.sshState == sshCheckFailed {
+				m.selectedHost.sshState = sshCheckNone
 			}
 			return m, m.hostStatusCmd(m.selectedHost)
 
@@ -570,7 +576,7 @@ func (m *Model) handleHostHoverMsg(msg hostHoverMsg) tea.Cmd {
 		return nil
 	}
 
-	if host.sshChecked && !host.sshReachable {
+	if host.sshState == sshCheckFailed {
 		// SSH check previously failed; user must press `s` to retry.
 		return nil
 	}
@@ -643,10 +649,10 @@ func (m *Model) hostSSHCheckCmd(host *hostModel) tea.Cmd {
 	}
 
 	// Prevent duplicate in-flight checks.
-	if host.sshChecking {
+	if host.sshState == sshCheckPending {
 		return nil
 	}
-	host.sshChecking = true
+	host.sshState = sshCheckPending
 
 	// Show the user we're checking connectivity.
 	intro := lipgloss.NewStyle().
@@ -665,18 +671,15 @@ func (m *Model) hostSSHCheckCmd(host *hostModel) tea.Cmd {
 
 func (m *Model) handleHostSSHCheckMsg(msg hostSSHCheckMsg) tea.Cmd {
 	host := m.hosts[msg.hostName]
-	host.sshChecking = false
-	host.sshChecked = true
-
 	if msg.err == nil {
 		slog.Debug("SSH check passed", "host", msg.hostName)
-		host.sshReachable = true
+		host.sshState = sshCheckPassed
 
 		// Proceed with status collection.
 		return m.hostStatusCmd(host)
 	}
 
-	host.sshReachable = false
+	host.sshState = sshCheckFailed
 
 	checkErr, ok := msg.err.(*runner.SSHCheckError)
 	if !ok {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -74,6 +74,7 @@ type hostModel struct {
 	name    string
 	target  *nix.TargetInfo // Cached info about target host.
 	hostTab int             // Currently visible host tab.
+	sshChecking  bool       // Whether an SSH pre-flight check is currently in-flight.
 	sshChecked   bool       // Whether SSH connectivity has been verified.
 	sshReachable bool       // Whether the SSH connectivity check passed.
 	deploy  struct {
@@ -378,6 +379,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Reset SSH check to allow re-checking on explicit status request.
 			if m.selectedHost != nil && !m.selectedHost.sshReachable {
 				m.selectedHost.sshChecked = false
+				m.selectedHost.sshChecking = false
 			}
 			return m, m.hostStatusCmd(m.selectedHost)
 
@@ -640,6 +642,12 @@ func (m *Model) hostSSHCheckCmd(host *hostModel) tea.Cmd {
 		return nil
 	}
 
+	// Prevent duplicate in-flight checks.
+	if host.sshChecking {
+		return nil
+	}
+	host.sshChecking = true
+
 	// Show the user we're checking connectivity.
 	intro := lipgloss.NewStyle().
 		Foreground(subtleColor).
@@ -657,6 +665,7 @@ func (m *Model) hostSSHCheckCmd(host *hostModel) tea.Cmd {
 
 func (m *Model) handleHostSSHCheckMsg(msg hostSSHCheckMsg) tea.Cmd {
 	host := m.hosts[msg.hostName]
+	host.sshChecking = false
 	host.sshChecked = true
 
 	if msg.err == nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -74,6 +74,8 @@ type hostModel struct {
 	name    string
 	target  *nix.TargetInfo // Cached info about target host.
 	hostTab int             // Currently visible host tab.
+	sshChecked   bool       // Whether SSH connectivity has been verified.
+	sshReachable bool       // Whether the SSH connectivity check passed.
 	deploy  struct {
 		intro        string // Rendered intro text: command, host, etc.
 		contentPanel viewport.Model
@@ -190,6 +192,11 @@ type confirmationMsg struct {
 type textInputPromptMsg struct {
 	prompt   string
 	submitFn func(string) tea.Cmd
+}
+
+type hostSSHCheckMsg struct {
+	hostName string
+	err      error // nil on success, *runner.SSHCheckError on failure.
 }
 
 type criticalErrorMsg struct {
@@ -368,6 +375,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case key.Matches(msg, m.keys.Status):
+			// Reset SSH check to allow re-checking on explicit status request.
+			if m.selectedHost != nil {
+				m.selectedHost.sshChecked = false
+			}
 			return m, m.hostStatusCmd(m.selectedHost)
 
 		case key.Matches(msg, m.keys.SSHInto):
@@ -404,6 +415,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case hostRunCommandOutputMsg:
 		return m, m.handleHostRunCommandOutputMsg(msg)
+
+	case hostSSHCheckMsg:
+		return m, m.handleHostSSHCheckMsg(msg)
 
 	case hostStatusMsg:
 		return m, m.handleHostStatusMsg(msg)
@@ -554,6 +568,11 @@ func (m *Model) handleHostHoverMsg(msg hostHoverMsg) tea.Cmd {
 		return nil
 	}
 
+	if host.sshChecked && !host.sshReachable {
+		// SSH check previously failed; user must press `s` to retry.
+		return nil
+	}
+
 	return m.hostStatusCmd(host)
 }
 
@@ -612,8 +631,61 @@ func (m *Model) handleHostTargetInfoMsg(msg hostTargetInfoMsg) tea.Cmd {
 		host.target.DeployUser = m.config.Hosts.DefaultSSHUser
 	}
 
-	// Fetch host status now that we know target info.
-	return m.hostStatusCmd(host)
+	// Verify SSH connectivity before attempting status.
+	return m.hostSSHCheckCmd(host)
+}
+
+func (m *Model) hostSSHCheckCmd(host *hostModel) tea.Cmd {
+	if host.target == nil {
+		return nil
+	}
+
+	// Show the user we're checking connectivity.
+	intro := lipgloss.NewStyle().
+		Foreground(subtleColor).
+		Render("Checking SSH connectivity to " + host.target.DeployHost + "...") + "\n"
+	host.status.contentPanel.SetContent(intro)
+
+	user := host.target.DeployUser
+	hostParam := host.target.DeployHost
+
+	return func() tea.Msg {
+		err := runner.CheckSSH(m.ctx, hostParam, user)
+		return hostSSHCheckMsg{hostName: host.name, err: err}
+	}
+}
+
+func (m *Model) handleHostSSHCheckMsg(msg hostSSHCheckMsg) tea.Cmd {
+	host := m.hosts[msg.hostName]
+	host.sshChecked = true
+
+	if msg.err == nil {
+		slog.Debug("SSH check passed", "host", msg.hostName)
+		host.sshReachable = true
+
+		// Proceed with status collection.
+		return m.hostStatusCmd(host)
+	}
+
+	host.sshReachable = false
+
+	checkErr, ok := msg.err.(*runner.SSHCheckError)
+	if !ok {
+		slog.Error("SSH check returned unexpected error type", "host", msg.hostName, "err", msg.err)
+		return func() tea.Msg {
+			return criticalErrorMsg{detail: "SSH check failed: " + msg.err.Error()}
+		}
+	}
+
+	slog.Warn("SSH check failed", "host", msg.hostName, "message", checkErr.Message)
+
+	// Show error in status panel.
+	detail := lipgloss.NewStyle().Foreground(errorColor).Render(checkErr.Message) +
+		"\n\n" + checkErr.Suggestion +
+		"\n\n" + subtleStyle.Render("Press `i` to connect interactively or `s` to retry after fixing.")
+	host.status.contentPanel.SetContent(detail)
+
+	return nil
 }
 
 func (m *Model) fetchFlakeMetadataCmd() tea.Cmd {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -376,7 +376,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keys.Status):
 			// Reset SSH check to allow re-checking on explicit status request.
-			if m.selectedHost != nil {
+			if m.selectedHost != nil && !m.selectedHost.sshReachable {
 				m.selectedHost.sshChecked = false
 			}
 			return m, m.hostStatusCmd(m.selectedHost)


### PR DESCRIPTION
Add SSH connectivity pre-flight check before running host status commands.
When SSH fails (untrusted host key, auth failure, network issues), display
a user-friendly error with actionable suggestions instead of freezing the TUI.

- New runner.CheckSSH performs async SSH connectivity test
- SSH errors classified into friendly messages with fix instructions
- Deploy uses NIX_SSHOPTS=-oBatchMode=yes to prevent interactive prompts
- Press 's' to retry after fixing SSH issues

Implements ROADMAP 1.1.
