### PR TITLE
Replace text display dialog with scrollable viewport

### DIFF
--- a/internal/ui/dialog.go
+++ b/internal/ui/dialog.go
@@ -1,11 +1,14 @@
 package ui
 
 import (
+	"fmt"
 	"image/color"
 
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/jhillyerd/labcoat/internal/config"
 )
 
 // Dialog is a reusable modal dialog that overlays content on top of a background.
@@ -35,6 +38,92 @@ func (d *Dialog) View() string {
 // Overlay renders the Dialog centered on top of the background content using
 // the lipgloss compositor for proper layering.
 func (d *Dialog) Overlay(background string, width, height int) string {
+	dialog := d.View()
+
+	bgLayer := lipgloss.NewLayer(background)
+	dialogLayer := lipgloss.NewLayer(dialog)
+
+	dialogW := lipgloss.Width(dialog)
+	dialogH := lipgloss.Height(dialog)
+	centerX := (width - dialogW) / 2
+	centerY := (height - dialogH) / 2
+
+	dialogLayer.X(centerX).Y(centerY).Z(1)
+
+	compositor := lipgloss.NewCompositor(bgLayer, dialogLayer)
+	return compositor.Render()
+}
+
+// ScrollableDialog is a modal dialog with a scrollable viewport for displaying
+// long text content. It supports PgUp/PgDn for scrolling and Esc to dismiss.
+type ScrollableDialog struct {
+	viewport    viewport.Model
+	borderColor color.Color
+	keys        config.KeyMap
+}
+
+const scrollableDialogPadding = 0
+const scrollableDialogBorder = 2 // 1 per side
+
+// NewScrollableDialog creates a scrollable dialog sized to fit within the
+// given screen dimensions, displaying the provided content.
+func NewScrollableDialog(content string, borderColor color.Color, screenW, screenH int, keys config.KeyMap) *ScrollableDialog {
+	// Dialog occupies 80% of screen, max 120 wide, centered.
+	w := min(120, screenW*80/100)
+	h := min(screenH-4, screenH*80/100)
+
+	// Inner viewport dimensions minus padding and border.
+	vpW := w - 2*scrollableDialogPadding - scrollableDialogBorder
+	vpH := h - scrollableDialogBorder - 2 // blank line + footer hint
+
+	vp := viewport.New(viewport.WithWidth(vpW), viewport.WithHeight(vpH))
+	vp.KeyMap.PageUp = keys.ScrollUp
+	vp.KeyMap.PageDown = keys.ScrollDown
+	vp.SetContent(content)
+	vp.GotoTop()
+
+	return &ScrollableDialog{
+		viewport:    vp,
+		borderColor: borderColor,
+		keys:        keys,
+	}
+}
+
+// Update handles key events for scrolling. Returns true if the dialog should
+// be dismissed.
+func (d *ScrollableDialog) Update(msg tea.Msg) (dismiss bool, cmd tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "esc", "enter":
+			return true, nil
+		}
+	}
+
+	d.viewport, cmd = d.viewport.Update(msg)
+	return false, cmd
+}
+
+// View renders the dialog content with border and hint.
+func (d *ScrollableDialog) View() string {
+	scroll := "(END)"
+	if !d.viewport.AtBottom() {
+		scroll = fmt.Sprintf("%.0f%%", d.viewport.ScrollPercent()*100)
+	}
+
+	hint := subtleStyle.Render(fmt.Sprintf("PgUp/PgDn: scroll • Esc: close • %s", scroll))
+	body := d.viewport.View() + "\n\n" + hint
+
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(d.borderColor).
+		Padding(0, 1)
+
+	return style.Render(body)
+}
+
+// Overlay renders the dialog centered on top of the background content.
+func (d *ScrollableDialog) Overlay(background string, width, height int) string {
 	dialog := d.View()
 
 	bgLayer := lipgloss.NewLayer(background)

--- a/internal/ui/dialog.go
+++ b/internal/ui/dialog.go
@@ -72,21 +72,48 @@ func NewScrollableDialog(content string, borderColor color.Color, screenW, scree
 	w := min(120, screenW*80/100)
 	h := min(screenH-4, screenH*80/100)
 
-	// Inner viewport dimensions minus padding and border.
-	vpW := w - 2*scrollableDialogPadding - scrollableDialogBorder
-	vpH := h - scrollableDialogBorder - 2 // blank line + footer hint
-
-	vp := viewport.New(viewport.WithWidth(vpW), viewport.WithHeight(vpH))
-	vp.KeyMap.PageUp = keys.ScrollUp
-	vp.KeyMap.PageDown = keys.ScrollDown
-	vp.SetContent(content)
-	vp.GotoTop()
-
-	return &ScrollableDialog{
-		viewport:    vp,
+	d := &ScrollableDialog{
 		borderColor: borderColor,
 		keys:        keys,
 	}
+	d.initViewport(content, w, h)
+	return d
+}
+
+func (d *ScrollableDialog) initViewport(content string, w, h int) {
+	// Clamp to minimum usable dimensions.
+	w = max(w, 20)
+	h = max(h, 6)
+
+	// Inner viewport dimensions minus border and footer.
+	vpW := w - 2*scrollableDialogPadding - scrollableDialogBorder
+	vpH := h - scrollableDialogBorder - 2 // blank line + footer hint
+	vpW = max(vpW, 10)
+	vpH = max(vpH, 3)
+
+	vp := viewport.New(viewport.WithWidth(vpW), viewport.WithHeight(vpH))
+	vp.KeyMap.PageUp = d.keys.ScrollUp
+	vp.KeyMap.PageDown = d.keys.ScrollDown
+	vp.SetContent(content)
+	vp.GotoTop()
+	d.viewport = vp
+}
+
+// Resize updates the dialog dimensions to fit new screen size.
+func (d *ScrollableDialog) Resize(screenW, screenH int) {
+	w := min(120, screenW*80/100)
+	h := min(screenH-4, screenH*80/100)
+
+	w = max(w, 20)
+	h = max(h, 6)
+
+	vpW := w - 2*scrollableDialogPadding - scrollableDialogBorder
+	vpH := h - scrollableDialogBorder - 2
+	vpW = max(vpW, 10)
+	vpH = max(vpH, 3)
+
+	d.viewport.SetWidth(vpW)
+	d.viewport.SetHeight(vpH)
 }
 
 // Update handles key events for scrolling. Returns true if the dialog should
@@ -111,7 +138,7 @@ func (d *ScrollableDialog) View() string {
 		scroll = fmt.Sprintf("%.0f%%", d.viewport.ScrollPercent()*100)
 	}
 
-	hint := subtleStyle.Render(fmt.Sprintf("PgUp/PgDn: scroll • Esc: close • %s", scroll))
+	hint := subtleStyle.Render(fmt.Sprintf("PgUp/PgDn: scroll • Esc/Enter: close • %s", scroll))
 	body := d.viewport.View() + "\n\n" + hint
 
 	style := lipgloss.NewStyle().

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -63,7 +63,7 @@ type Model struct {
 	confirmation   *confirmationMsg
 	commandPalette *CommandPalette
 	inputOverlay   *InputOverlay
-	text           string
+	textDialog     *ScrollableDialog
 	error          string
 	flashText      string
 	flashTimer     *time.Timer
@@ -249,10 +249,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.viewMode == viewModeText {
-			// Any key to continue.
+			if m.textDialog != nil {
+				dismiss, cmd := m.textDialog.Update(msg)
+				if dismiss {
+					m.viewMode = viewModeHosts
+					m.textDialog = nil
+				}
+				return m, cmd
+			}
+			// Fallback: dismiss on any key if no dialog.
 			m.viewMode = viewModeHosts
-			m.text = ""
-
 			return m, nil
 		}
 
@@ -393,11 +399,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startHostInteractiveSSH()
 
 		case key.Matches(msg, m.keys.Help):
-			m.viewMode = viewModeText
-			m.text = labelStyle.Render("Help") +
-				"\n\n" +
-				m.help.FullHelpView(m.keys.FullHelp())
-			return m, nil
+			return m, func() tea.Msg {
+				return textDisplayMsg{
+					text: labelStyle.Render("Help") +
+						"\n\n" +
+						m.help.FullHelpView(m.keys.FullHelp()),
+				}
+			}
 
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
@@ -466,7 +474,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case textDisplayMsg:
 		m.viewMode = viewModeText
-		m.text = msg.text
+		m.textDialog = NewScrollableDialog(
+			msg.text, lipgloss.Color("#7dcfff"),
+			m.sizes.screen.width, m.sizes.screen.height,
+			m.keys)
 		return m, nil
 
 	case *tea.Program:
@@ -928,9 +939,9 @@ func (m Model) View() tea.View {
 
 	switch m.viewMode {
 	case viewModeText:
-		dialogContent := m.text + "\n\n" + subtleStyle.Render("[Press any key to continue]")
-		dialog := NewDialog(dialogContent, lipgloss.Color("#7dcfff"))
-		content = dialog.Overlay(content, m.sizes.screen.width, m.sizes.screen.height)
+		if m.textDialog != nil {
+			content = m.textDialog.Overlay(content, m.sizes.screen.width, m.sizes.screen.height)
+		}
 
 	case viewModeError:
 		dialogContent := labelStyle.Render("Critical Error") +

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -449,6 +449,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.hostList.SetSize(m.sizes.hostList.width, m.sizes.hostList.height)
 		m.updateContentPanel()
 
+		if m.textDialog != nil {
+			m.textDialog.Resize(m.sizes.screen.width, m.sizes.screen.height)
+		}
+
 		return m, nil
 
 	case confirmationMsg:


### PR DESCRIPTION
The :fingerprints, :deployments, :hosts, and ? help views could overflow
the screen with no way to scroll. Replace the simple Dialog used for
textDisplayMsg with a new ScrollableDialog that wraps a viewport.Model,
constrained to 80% of screen (max 120 wide), with PgUp/PgDn scrolling
and Esc/Enter to dismiss.
