### PR TITLE
Persist deployment history per host (ROADMAP 1.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ go vet ./...                    # Run go vet
 go fmt ./...                    # Format code
 ```
 
+Always run `go fmt` and `go test` after making changes to prevent CI failures.
+
 ## Code Style Guidelines
 
 ### Imports

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 | # | Item | Rationale |
 |---|------|-----------|
 | 1.1 | ~~**Fix SSH trust lockup (#34)**~~ | ✅ Done — SSH pre-flight check with inline diagnostics, in-flight guard, and exec error classification. |
-| 1.2 | **Persist deployment history per host** | Building on the flake fingerprinting from #38, record each deployment (timestamp, fingerprint, success/failure) per host in BoltDB so we can later compare against target state and support rollback.
+| 1.2 | ~~**Persist deployment history per host**~~ | ✅ Done — Deployment records (timestamp, fingerprint, success/failure) persisted per host in BoltDB. `deployments` command added to palette. |
 | 1.3 | **Ping-based reboot tracking** | Half-finished feature in README checklist. After issuing a reboot, poll with `ping` / `ssh` to detect when the host comes back, then auto-refresh status. |
 | 1.4 | **Better error surfacing** | Extend modal dialogs to cover runner failures, flake parse errors, etc. so the user never needs to check a separate log. (SSH error surfacing done in #34.) |
 

--- a/internal/store/boltdb.go
+++ b/internal/store/boltdb.go
@@ -332,10 +332,10 @@ func (b *BoltDB) HostsCommitsBehind(hosts []string) (map[string]CommitsBehindInf
 			continue
 		}
 
-		// Count clean versions stored after the deployed version.
+		// Count clean versions modified after the deployed version.
 		behind := 0
 		for _, v := range versions {
-			if v.StoredAt.After(deployVer.StoredAt) && !v.Dirty {
+			if v.LastModified.After(deployVer.LastModified) && !v.Dirty {
 				behind++
 			}
 		}

--- a/internal/store/boltdb.go
+++ b/internal/store/boltdb.go
@@ -3,9 +3,10 @@ package store
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/vmihailenco/msgpack/v5"
 	"slices"
 	"time"
+
+	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/jhillyerd/labcoat/internal/nix"
 	bolt "go.etcd.io/bbolt"
@@ -14,6 +15,7 @@ import (
 const (
 	flakeVersions = "flake-versions"
 	hostLogs      = "host-logs"
+	deployHistory = "deploy-history"
 )
 
 type BoltDB struct {
@@ -22,7 +24,7 @@ type BoltDB struct {
 
 func NewBoltDB(db *bolt.DB) (*BoltDB, error) {
 	err := db.Update(func(tx *bolt.Tx) error {
-		for _, name := range []string{flakeVersions, hostLogs} {
+		for _, name := range []string{flakeVersions, hostLogs, deployHistory} {
 			if _, err := tx.CreateBucketIfNotExists([]byte(name)); err != nil {
 				return fmt.Errorf("Failed to create %q root bucket: %w", name, err)
 			}
@@ -200,4 +202,94 @@ func (b *BoltDB) GetFlakeVersion(fingerprint string) (*FlakeVersion, error) {
 	})
 
 	return version, err
+}
+
+// DeploymentRecord represents a single deployment attempt for a host.
+type DeploymentRecord struct {
+	Timestamp   time.Time
+	Fingerprint string
+	Success     bool
+}
+
+// RecordDeployment records a deployment attempt for a host.
+func (b *BoltDB) RecordDeployment(host string, record DeploymentRecord) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(deployHistory))
+		if root == nil {
+			return fmt.Errorf("Failed to get %q bucket, was nil", deployHistory)
+		}
+		bucket, err := root.CreateBucketIfNotExists([]byte(host))
+		if err != nil {
+			return fmt.Errorf("Failed to create %q deployment bucket: %w", host, err)
+		}
+
+		data, err := msgpack.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("Failed to marshal deployment record: %w", err)
+		}
+
+		return bucket.Put(ttob(record.Timestamp), data)
+	})
+}
+
+// ListDeployments returns deployment history for a host, most recent first.
+func (b *BoltDB) ListDeployments(host string) ([]DeploymentRecord, error) {
+	var records []DeploymentRecord
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(deployHistory))
+		if root == nil {
+			return fmt.Errorf("Failed to get %q bucket, was nil", deployHistory)
+		}
+		bucket := root.Bucket([]byte(host))
+		if bucket == nil {
+			return nil
+		}
+
+		// Keys are big-endian timestamps, so iterating Last/Prev yields
+		// most-recent-first without needing an in-memory sort.
+		c := bucket.Cursor()
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			var rec DeploymentRecord
+			if err := msgpack.Unmarshal(v, &rec); err != nil {
+				return fmt.Errorf("Failed to unmarshal deployment record: %w", err)
+			}
+			records = append(records, rec)
+		}
+
+		return nil
+	})
+
+	return records, err
+}
+
+// LatestDeployment returns the most recent deployment for a host, or nil if none.
+func (b *BoltDB) LatestDeployment(host string) (*DeploymentRecord, error) {
+	var record *DeploymentRecord
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(deployHistory))
+		if root == nil {
+			return nil
+		}
+		bucket := root.Bucket([]byte(host))
+		if bucket == nil {
+			return nil
+		}
+
+		// Keys are big-endian timestamps, so last key is most recent.
+		_, v := bucket.Cursor().Last()
+		if v == nil {
+			return nil
+		}
+
+		var rec DeploymentRecord
+		if err := msgpack.Unmarshal(v, &rec); err != nil {
+			return fmt.Errorf("Failed to unmarshal deployment record: %w", err)
+		}
+		record = &rec
+		return nil
+	})
+
+	return record, err
 }

--- a/internal/store/boltdb.go
+++ b/internal/store/boltdb.go
@@ -270,7 +270,7 @@ func (b *BoltDB) LatestDeployment(host string) (*DeploymentRecord, error) {
 	err := b.db.View(func(tx *bolt.Tx) error {
 		root := tx.Bucket([]byte(deployHistory))
 		if root == nil {
-			return nil
+			return fmt.Errorf("Failed to get %q bucket, was nil", deployHistory)
 		}
 		bucket := root.Bucket([]byte(host))
 		if bucket == nil {
@@ -294,6 +294,41 @@ func (b *BoltDB) LatestDeployment(host string) (*DeploymentRecord, error) {
 	return record, err
 }
 
+// LatestSuccessfulDeployment returns the most recent successful deployment for a
+// host, or nil if none.
+func (b *BoltDB) LatestSuccessfulDeployment(host string) (*DeploymentRecord, error) {
+	var record *DeploymentRecord
+
+	err := b.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(deployHistory))
+		if root == nil {
+			return fmt.Errorf("Failed to get %q bucket, was nil", deployHistory)
+		}
+		bucket := root.Bucket([]byte(host))
+		if bucket == nil {
+			return nil
+		}
+
+		// Keys are big-endian timestamps, so iterating Last/Prev yields
+		// most-recent-first. Return the first record with Success == true.
+		c := bucket.Cursor()
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			var rec DeploymentRecord
+			if err := msgpack.Unmarshal(v, &rec); err != nil {
+				return fmt.Errorf("Failed to unmarshal deployment record: %w", err)
+			}
+			if rec.Success {
+				record = &rec
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	return record, err
+}
+
 // CommitsBehindInfo contains behind-count information for a host's deployment.
 type CommitsBehindInfo struct {
 	Behind int
@@ -301,8 +336,8 @@ type CommitsBehindInfo struct {
 }
 
 // HostsCommitsBehind returns the number of clean (non-dirty) flake versions stored after
-// each host's most recent deployment, and whether that deployment was from a dirty tree.
-// Hosts with no deployment or whose fingerprint is not stored are omitted from the result.
+// each host's most recent successful deployment, and whether that deployment was from a dirty tree.
+// Hosts with no successful deployment or whose fingerprint is not stored are omitted from the result.
 func (b *BoltDB) HostsCommitsBehind(hosts []string) (map[string]CommitsBehindInfo, error) {
 	versions, err := b.ListFlakeVersions()
 	if err != nil {
@@ -312,7 +347,7 @@ func (b *BoltDB) HostsCommitsBehind(hosts []string) (map[string]CommitsBehindInf
 	result := make(map[string]CommitsBehindInfo, len(hosts))
 
 	for _, host := range hosts {
-		deploy, err := b.LatestDeployment(host)
+		deploy, err := b.LatestSuccessfulDeployment(host)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get latest deployment for %q: %w", host, err)
 		}

--- a/internal/store/boltdb.go
+++ b/internal/store/boltdb.go
@@ -293,3 +293,58 @@ func (b *BoltDB) LatestDeployment(host string) (*DeploymentRecord, error) {
 
 	return record, err
 }
+
+// CommitsBehindInfo contains behind-count information for a host's deployment.
+type CommitsBehindInfo struct {
+	Behind int
+	Dirty  bool
+}
+
+// HostsCommitsBehind returns the number of clean (non-dirty) flake versions stored after
+// each host's most recent deployment, and whether that deployment was from a dirty tree.
+// Hosts with no deployment or whose fingerprint is not stored are omitted from the result.
+func (b *BoltDB) HostsCommitsBehind(hosts []string) (map[string]CommitsBehindInfo, error) {
+	versions, err := b.ListFlakeVersions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list flake versions: %w", err)
+	}
+
+	result := make(map[string]CommitsBehindInfo, len(hosts))
+
+	for _, host := range hosts {
+		deploy, err := b.LatestDeployment(host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest deployment for %q: %w", host, err)
+		}
+		if deploy == nil {
+			continue
+		}
+
+		// Find the deployed version in the versions list.
+		var deployVer *FlakeVersion
+		for i := range versions {
+			if versions[i].Fingerprint == deploy.Fingerprint {
+				deployVer = &versions[i]
+				break
+			}
+		}
+		if deployVer == nil {
+			continue
+		}
+
+		// Count clean versions stored after the deployed version.
+		behind := 0
+		for _, v := range versions {
+			if v.StoredAt.After(deployVer.StoredAt) && !v.Dirty {
+				behind++
+			}
+		}
+
+		result[host] = CommitsBehindInfo{
+			Behind: behind,
+			Dirty:  deployVer.Dirty,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/store/boltdb_test.go
+++ b/internal/store/boltdb_test.go
@@ -51,7 +51,7 @@ func TestListDeploymentsOrderedByMostRecent(t *testing.T) {
 	bdb := setupTestDB(t)
 	host := "myhost"
 
-	// Insert in chronological order.
+	// Insert out of chronological order.
 	records := []DeploymentRecord{
 		{Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Fingerprint: "aaa", Success: true},
 		{Timestamp: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC), Fingerprint: "bbb", Success: false},
@@ -135,6 +135,63 @@ func TestLatestDeployment(t *testing.T) {
 	require.NotNil(t, rec)
 	assert.Equal(t, "new", rec.Fingerprint)
 	assert.False(t, rec.Success)
+}
+
+func TestLatestSuccessfulDeploymentNone(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	rec, err := bdb.LatestSuccessfulDeployment("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, rec)
+}
+
+func TestLatestSuccessfulDeployment(t *testing.T) {
+	bdb := setupTestDB(t)
+	host := "myhost"
+
+	err := bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "old-ok",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	err = bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "mid-fail",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	err = bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "new-fail",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	// Should skip failed deployments and return the oldest successful one.
+	rec, err := bdb.LatestSuccessfulDeployment(host)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, "old-ok", rec.Fingerprint)
+	assert.True(t, rec.Success)
+}
+
+func TestLatestSuccessfulDeploymentAllFailed(t *testing.T) {
+	bdb := setupTestDB(t)
+	host := "myhost"
+
+	err := bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "fail1",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	rec, err := bdb.LatestSuccessfulDeployment(host)
+	require.NoError(t, err)
+	assert.Nil(t, rec)
 }
 
 // --- FlakeVersion tests ---
@@ -240,7 +297,7 @@ func TestHostsCommitsBehindUpToDate(t *testing.T) {
 	assert.Equal(t, CommitsBehindInfo{Behind: 0, Dirty: false}, result["host-a"])
 }
 
-func TestHostsCommitsBehindThreeCommitsBehind(t *testing.T) {
+func TestHostsCommitsBehindTwoCommitsBehind(t *testing.T) {
 	bdb := setupTestDB(t)
 
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
@@ -323,6 +380,74 @@ func TestHostsCommitsBehindFingerprintNotStored(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := result["host-a"]
 	assert.False(t, ok, "host with untracked fingerprint should be omitted")
+}
+
+func TestHostsCommitsBehindSkipsFailedDeployment(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint:  "fp-old",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint:  "fp-failed",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint:  "fp-new",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
+	})
+
+	// Successful deployment of fp-old.
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-old",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	// Failed deployment of fp-failed — should be ignored.
+	err = bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 2, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-failed",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	// Should be based on fp-old (successful), so 2 clean versions after it
+	// (fp-failed and fp-new), not 1 as it would be if based on fp-failed.
+	assert.Equal(t, CommitsBehindInfo{Behind: 2, Dirty: false}, result["host-a"])
+}
+
+func TestHostsCommitsBehindOnlyFailedDeploys(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint:  "fp1",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp1",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	_, ok := result["host-a"]
+	assert.False(t, ok, "host with only failed deployments should be omitted")
 }
 
 func TestHostsCommitsBehindMultipleHosts(t *testing.T) {

--- a/internal/store/boltdb_test.go
+++ b/internal/store/boltdb_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -199,5 +198,159 @@ func TestWriteAndReadHostLogs(t *testing.T) {
 	assert.Equal(t, "entry 2", entries[1].Entry)
 }
 
-// Silence unused import warning for os.
-var _ = os.DevNull
+// --- HostsCommitsBehind tests ---
+
+func storeTestFlakeVersion(t *testing.T, bdb *BoltDB, fv FlakeVersion) {
+	t.Helper()
+	err := bdb.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(flakeVersions))
+		data, err := msgpack.Marshal(fv)
+		require.NoError(t, err)
+		return bucket.Put([]byte(fv.Fingerprint), data)
+	})
+	require.NoError(t, err)
+}
+
+func TestHostsCommitsBehindNoDeployments(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestHostsCommitsBehindUpToDate(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp1",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp1",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	assert.Equal(t, CommitsBehindInfo{Behind: 0, Dirty: false}, result["host-a"])
+}
+
+func TestHostsCommitsBehindThreeCommitsBehind(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-old",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-mid",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-dirty",
+		Dirty:       true,
+		StoredAt:    time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-new",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC),
+	})
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-old",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	// fp-mid and fp-new are clean versions after fp-old; fp-dirty is skipped.
+	assert.Equal(t, CommitsBehindInfo{Behind: 2, Dirty: false}, result["host-a"])
+}
+
+func TestHostsCommitsBehindDirtyDeploy(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-dirty",
+		Dirty:       true,
+		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-clean",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+	})
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-dirty",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	assert.Equal(t, CommitsBehindInfo{Behind: 1, Dirty: true}, result["host-a"])
+}
+
+func TestHostsCommitsBehindFingerprintNotStored(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-missing",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a"})
+	require.NoError(t, err)
+	_, ok := result["host-a"]
+	assert.False(t, ok, "host with untracked fingerprint should be omitted")
+}
+
+func TestHostsCommitsBehindMultipleHosts(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-1",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	})
+	storeTestFlakeVersion(t, bdb, FlakeVersion{
+		Fingerprint: "fp-2",
+		Dirty:       false,
+		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+	})
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-1",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	err = bdb.RecordDeployment("host-b", DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 2, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "fp-2",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	result, err := bdb.HostsCommitsBehind([]string{"host-a", "host-b", "host-c"})
+	require.NoError(t, err)
+	assert.Equal(t, CommitsBehindInfo{Behind: 1, Dirty: false}, result["host-a"])
+	assert.Equal(t, CommitsBehindInfo{Behind: 0, Dirty: false}, result["host-b"])
+	_, ok := result["host-c"]
+	assert.False(t, ok, "host with no deployments should be omitted")
+}

--- a/internal/store/boltdb_test.go
+++ b/internal/store/boltdb_test.go
@@ -244,24 +244,28 @@ func TestHostsCommitsBehindThreeCommitsBehind(t *testing.T) {
 	bdb := setupTestDB(t)
 
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-old",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-old",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	})
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-mid",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-mid",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
 	})
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-dirty",
-		Dirty:       true,
-		StoredAt:    time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-dirty",
+		Dirty:        true,
+		LastModified: time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC),
 	})
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-new",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-new",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC),
 	})
 
 	err := bdb.RecordDeployment("host-a", DeploymentRecord{
@@ -281,14 +285,16 @@ func TestHostsCommitsBehindDirtyDeploy(t *testing.T) {
 	bdb := setupTestDB(t)
 
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-dirty",
-		Dirty:       true,
-		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-dirty",
+		Dirty:        true,
+		LastModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	})
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-clean",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-clean",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
 	})
 
 	err := bdb.RecordDeployment("host-a", DeploymentRecord{
@@ -323,14 +329,16 @@ func TestHostsCommitsBehindMultipleHosts(t *testing.T) {
 	bdb := setupTestDB(t)
 
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-1",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-1",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	})
 	storeTestFlakeVersion(t, bdb, FlakeVersion{
-		Fingerprint: "fp-2",
-		Dirty:       false,
-		StoredAt:    time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp-2",
+		Dirty:        false,
+		LastModified: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		StoredAt:     time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
 	})
 
 	err := bdb.RecordDeployment("host-a", DeploymentRecord{

--- a/internal/store/boltdb_test.go
+++ b/internal/store/boltdb_test.go
@@ -1,0 +1,203 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+	bolt "go.etcd.io/bbolt"
+)
+
+func setupTestDB(t *testing.T) *BoltDB {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := bolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	bdb, err := NewBoltDB(db)
+	require.NoError(t, err)
+	return bdb
+}
+
+func TestRecordDeployment(t *testing.T) {
+	bdb := setupTestDB(t)
+	host := "testhost"
+
+	record := DeploymentRecord{
+		Timestamp:   time.Date(2025, 5, 1, 12, 0, 0, 0, time.UTC),
+		Fingerprint: "abc123def456",
+		Success:     true,
+	}
+
+	err := bdb.RecordDeployment(host, record)
+	require.NoError(t, err)
+}
+
+func TestListDeploymentsEmpty(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	records, err := bdb.ListDeployments("nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestListDeploymentsOrderedByMostRecent(t *testing.T) {
+	bdb := setupTestDB(t)
+	host := "myhost"
+
+	// Insert in chronological order.
+	records := []DeploymentRecord{
+		{Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Fingerprint: "aaa", Success: true},
+		{Timestamp: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC), Fingerprint: "bbb", Success: false},
+		{Timestamp: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC), Fingerprint: "ccc", Success: true},
+	}
+
+	for _, r := range records {
+		err := bdb.RecordDeployment(host, r)
+		require.NoError(t, err)
+	}
+
+	got, err := bdb.ListDeployments(host)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// Should be most recent first.
+	assert.Equal(t, "bbb", got[0].Fingerprint)
+	assert.False(t, got[0].Success)
+	assert.Equal(t, "ccc", got[1].Fingerprint)
+	assert.True(t, got[1].Success)
+	assert.Equal(t, "aaa", got[2].Fingerprint)
+	assert.True(t, got[2].Success)
+}
+
+func TestListDeploymentsPerHostIsolation(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	err := bdb.RecordDeployment("host-a", DeploymentRecord{
+		Timestamp:   time.Now(),
+		Fingerprint: "fp-a",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	err = bdb.RecordDeployment("host-b", DeploymentRecord{
+		Timestamp:   time.Now(),
+		Fingerprint: "fp-b",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	recordsA, err := bdb.ListDeployments("host-a")
+	require.NoError(t, err)
+	require.Len(t, recordsA, 1)
+	assert.Equal(t, "fp-a", recordsA[0].Fingerprint)
+
+	recordsB, err := bdb.ListDeployments("host-b")
+	require.NoError(t, err)
+	require.Len(t, recordsB, 1)
+	assert.Equal(t, "fp-b", recordsB[0].Fingerprint)
+}
+
+func TestLatestDeploymentNone(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	rec, err := bdb.LatestDeployment("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, rec)
+}
+
+func TestLatestDeployment(t *testing.T) {
+	bdb := setupTestDB(t)
+	host := "myhost"
+
+	err := bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "old",
+		Success:     true,
+	})
+	require.NoError(t, err)
+
+	err = bdb.RecordDeployment(host, DeploymentRecord{
+		Timestamp:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint: "new",
+		Success:     false,
+	})
+	require.NoError(t, err)
+
+	rec, err := bdb.LatestDeployment(host)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, "new", rec.Fingerprint)
+	assert.False(t, rec.Success)
+}
+
+// --- FlakeVersion tests ---
+
+func TestStoreAndGetFlakeVersion(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	meta := FlakeVersion{
+		ResolvedUrl:  "github:nixos/nixpkgs",
+		Revision:     "abc123",
+		LastModified: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Fingerprint:  "fp123",
+		StoredAt:     time.Now(),
+	}
+
+	err := bdb.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(flakeVersions))
+		data, merr := msgpack.Marshal(meta)
+		require.NoError(t, merr)
+		return bucket.Put([]byte(meta.Fingerprint), data)
+	})
+	require.NoError(t, err)
+
+	got, err := bdb.GetFlakeVersion("fp123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "abc123", got.Revision)
+}
+
+func TestGetFlakeVersionNotFound(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	got, err := bdb.GetFlakeVersion("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// --- HostLog tests ---
+
+func TestReadHostLogsEmpty(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	entries, err := bdb.ReadHostLogs("nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestWriteAndReadHostLogs(t *testing.T) {
+	bdb := setupTestDB(t)
+
+	err := bdb.WriteHostLog("host1", "entry 1")
+	require.NoError(t, err)
+
+	err = bdb.WriteHostLog("host1", "entry 2")
+	require.NoError(t, err)
+
+	entries, err := bdb.ReadHostLogs("host1")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "entry 1", entries[0].Entry)
+	assert.Equal(t, "entry 2", entries[1].Entry)
+}
+
+// Silence unused import warning for os.
+var _ = os.DevNull

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -126,7 +126,7 @@ func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {
 		}
 		busyCmd := hostListDecrBusyCmd(host.name, status)
 
-		cmds = append(cmds, logCmd, busyCmd)
+		cmds = append(cmds, logCmd, busyCmd, m.fetchAllHostsBehindCmd())
 	} else {
 		// Schedule next update.
 		_, updateCmd := srunner.Update(nil)

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/jhillyerd/labcoat/internal/runner"
+	"github.com/jhillyerd/labcoat/internal/store"
 )
 
 type hostDeployMsg struct {
@@ -73,7 +75,11 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	host.deploy.intro = intro
 	host.deploy.contentPanel.SetContent(intro)
 
-	logCmd := m.hostLogCmd(host, fmt.Sprintf("NixOS deployment started, target: %s", targetHost))
+	logText := fmt.Sprintf("NixOS deployment started, target: %s", targetHost)
+	if m.flakeFingerprint != "" {
+		logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(m.flakeFingerprint))
+	}
+	logCmd := m.hostLogCmd(host, logText)
 	busyCmd := hostListIncrBusyCmd(host.name)
 	return tea.Batch(srunner.Init(m.program), logCmd, busyCmd)
 }
@@ -89,13 +95,33 @@ func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {
 	}
 
 	if msg.final {
+		success := srunner.Successful()
+
+		// Persist deployment record.
+		if m.flakeFingerprint != "" {
+			record := store.DeploymentRecord{
+				Timestamp:   time.Now(),
+				Fingerprint: m.flakeFingerprint,
+				Success:     success,
+			}
+			if err := m.db.RecordDeployment(host.name, record); err != nil {
+				slog.Error("Failed to record deployment", "host", host.name, "err", err)
+			}
+		} else {
+			slog.Warn("No flake fingerprint available, skipping deployment record", "host", host.name)
+		}
+
 		// Log completion.
+		logText := fmt.Sprintf("NixOS deployment finished: %s", srunner.StateString())
+		if m.flakeFingerprint != "" {
+			logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(m.flakeFingerprint))
+		}
 		logCmd := m.hostLogCmd(
 			msg.host,
-			fmt.Sprintf("NixOS deployment finished: %s", srunner.StateString()))
+			logText)
 
 		status := hostItemStatusSuccess
-		if !srunner.Successful() {
+		if !success {
 			status = hostItemStatusFailed
 		}
 		busyCmd := hostListDecrBusyCmd(host.name, status)

--- a/internal/ui/host_deploy.go
+++ b/internal/ui/host_deploy.go
@@ -67,6 +67,7 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	srunner.Styles.StatusSuffix = subtleStyle
 	host.deploy.runner = srunner
 	host.deploy.cancel = cancel
+	host.deploy.fingerprint = m.flakeFingerprint // Capture current fingerprint.
 
 	// Init status display.
 	intro := lipgloss.NewStyle().
@@ -76,8 +77,8 @@ func (m *Model) handleHostDeployMsg(msg hostDeployMsg) tea.Cmd {
 	host.deploy.contentPanel.SetContent(intro)
 
 	logText := fmt.Sprintf("NixOS deployment started, target: %s", targetHost)
-	if m.flakeFingerprint != "" {
-		logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(m.flakeFingerprint))
+	if host.deploy.fingerprint != "" {
+		logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(host.deploy.fingerprint))
 	}
 	logCmd := m.hostLogCmd(host, logText)
 	busyCmd := hostListIncrBusyCmd(host.name)
@@ -97,11 +98,13 @@ func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {
 	if msg.final {
 		success := srunner.Successful()
 
+		fp := host.deploy.fingerprint
+
 		// Persist deployment record.
-		if m.flakeFingerprint != "" {
+		if fp != "" {
 			record := store.DeploymentRecord{
 				Timestamp:   time.Now(),
-				Fingerprint: m.flakeFingerprint,
+				Fingerprint: fp,
 				Success:     success,
 			}
 			if err := m.db.RecordDeployment(host.name, record); err != nil {
@@ -113,8 +116,8 @@ func (m *Model) handleHostDeployOutputMsg(msg hostDeployOutputMsg) tea.Cmd {
 
 		// Log completion.
 		logText := fmt.Sprintf("NixOS deployment finished: %s", srunner.StateString())
-		if m.flakeFingerprint != "" {
-			logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(m.flakeFingerprint))
+		if fp != "" {
+			logText += fmt.Sprintf(", fingerprint: %s", shortFingerprint(fp))
 		}
 		logCmd := m.hostLogCmd(
 			msg.host,

--- a/internal/ui/host_list.go
+++ b/internal/ui/host_list.go
@@ -25,8 +25,9 @@ func newHostList(hosts []string) hostListModel {
 	items := make([]list.Item, 0, len(hosts))
 	for _, host := range hosts {
 		items = append(items, hostItem{
-			name:      host,
-			busyCount: 0,
+			name:          host,
+			busyCount:     0,
+			commitsBehind: -1,
 		})
 	}
 
@@ -73,6 +74,8 @@ func (m hostListModel) Update(msg tea.Msg) (hostListModel, tea.Cmd) {
 	case jumpToLetterMsg:
 		cmd = m.handleJumpToLetterMsg(msg)
 		cmds = append(cmds, cmd)
+	case hostsBehindMsg:
+		m.handleHostsBehindMsg(msg)
 	case spinner.TickMsg:
 		*m.spinner, cmd = m.spinner.Update(msg)
 		cmds = append(cmds, cmd)
@@ -155,9 +158,11 @@ func (m *hostListModel) FilterState() list.FilterState {
 
 // hostItem represents an entry in the host list.
 type hostItem struct {
-	name      string
-	busyCount int // Number of active jobs for this host.
-	status    int // Status of most recent job for this host.
+	name          string
+	busyCount     int  // Number of active jobs for this host.
+	status        int  // Status of most recent job for this host.
+	commitsBehind int  // Number of clean commits behind latest; -1 means unknown/no deploy.
+	dirtyDeploy   bool // Last deploy was from a dirty working tree.
 }
 
 const (
@@ -168,6 +173,17 @@ const (
 
 func (item hostItem) FilterValue() string { return string(item.name) }
 func (item hostItem) String() string      { return string(item.name) }
+
+// behindInfo holds behind-count data for a single host.
+type behindInfo struct {
+	behind int
+	dirty  bool
+}
+
+// hostsBehindMsg updates the host list with behind-count data for all hosts.
+type hostsBehindMsg struct {
+	counts map[string]behindInfo
+}
 
 type itemDelegate struct {
 	spinner           *spinner.Model // Shared spinner for all items, updates handled by hostListModel.
@@ -191,6 +207,17 @@ func newItemDelegate(spinner *spinner.Model, maxWidth int) itemDelegate {
 func (d itemDelegate) Height() int                             { return 1 }
 func (d itemDelegate) Spacing() int                            { return 0 }
 func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (m *hostListModel) handleHostsBehindMsg(msg hostsBehindMsg) {
+	for i, h := range m.list.Items() {
+		item := h.(hostItem)
+		if info, ok := msg.counts[item.name]; ok {
+			item.commitsBehind = info.behind
+			item.dirtyDeploy = info.dirty
+			m.list.SetItem(i, item)
+		}
+	}
+}
 
 var (
 	renderedStatusSuccess = lipgloss.NewStyle().Foreground(successColor).Render("✓")
@@ -227,6 +254,27 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	}
 
 	line := style.Render(selected) + status + style.Render(item.name)
+
+	// Render the behind-count decoration, right-aligned.
+	if item.commitsBehind >= 0 {
+		behindStr := fmt.Sprintf("%d", item.commitsBehind)
+		if item.dirtyDeploy {
+			behindStr += "*"
+		} else {
+			behindStr += " "
+		}
+		behindRendered := subtleStyle.Render(behindStr)
+
+		lineLen := lipgloss.Width(line)
+		behindLen := lipgloss.Width(behindRendered)
+		pad := d.maxWidth - lineLen - behindLen
+
+		if pad > 1 {
+			line += strings.Repeat(" ", pad)
+		}
+		line += behindRendered
+	}
+
 	fmt.Fprint(w, d.itemStyle.MaxWidth(d.maxWidth).Render(line))
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -90,6 +90,7 @@ type hostModel struct {
 		contentPanel viewport.Model
 		runner       *runner.Model
 		cancel       func()
+		fingerprint  string // Captured at deploy start to avoid drift.
 	}
 	log struct {
 		contentPanel viewport.Model
@@ -1160,7 +1161,7 @@ func (m *Model) cmdListHosts() tea.Cmd {
 			line := "  " + name
 
 			// Show lastModified date from latest deployed fingerprint.
-			if deploy, err := m.db.LatestDeployment(name); err != nil {
+			if deploy, err := m.db.LatestSuccessfulDeployment(name); err != nil {
 				slog.Error("Failed to query latest deployment", "host", name, "err", err)
 			} else if deploy != nil {
 				if ver, err := m.db.GetFlakeVersion(deploy.Fingerprint); err != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1153,11 +1153,19 @@ func (m *Model) cmdListHosts() tea.Cmd {
 		slices.Sort(names)
 
 		for _, name := range names {
-			host := m.hosts[name]
 			line := "  " + name
-			if host.target != nil {
-				line += subtleStyle.Render(" → " + host.target.DeployHost)
+
+			// Show lastModified date from latest deployed fingerprint.
+			if deploy, err := m.db.LatestDeployment(name); err != nil {
+				slog.Error("Failed to query latest deployment", "host", name, "err", err)
+			} else if deploy != nil {
+				if ver, err := m.db.GetFlakeVersion(deploy.Fingerprint); err != nil {
+					slog.Error("Failed to query flake version", "host", name, "err", err)
+				} else if ver != nil {
+					line += subtleStyle.Render(" deployed revision " + ver.LastModified.Format(time.DateOnly))
+				}
 			}
+
 			b.WriteString(line + "\n")
 		}
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -42,32 +42,33 @@ const (
 var hostTabNames = []string{"Host Status", "Deploy", "Run Command", "Op Log"}
 
 type Model struct {
-	ctx            context.Context
-	program        *tea.Program
-	db             *store.BoltDB
-	config         config.Config
-	ready          bool // true once screen size is known.
-	viewMode       int  // Current UI mode.
-	flakePath      string
-	hostList       hostListModel
-	hosts          map[string]*hostModel
-	selectedHost   *hostModel
-	hoverTimerID   uint64 // Unique ID for each host hover timer.
-	nixPool        *npool.Pool
-	contentPanel   *viewport.Model
-	sizes          layoutSizes
-	keys           config.KeyMap
-	help           help.Model
-	spinner        spinner.Model
-	jumpToLetter   bool
-	confirmation   *confirmationMsg
-	commandPalette *CommandPalette
-	inputOverlay   *InputOverlay
-	textDialog     *ScrollableDialog
-	error          string
-	flashText      string
-	flashTimer     *time.Timer
-	cmdHistory     []string
+	ctx              context.Context
+	program          *tea.Program
+	db               *store.BoltDB
+	config           config.Config
+	ready            bool // true once screen size is known.
+	viewMode         int  // Current UI mode.
+	flakePath        string
+	flakeFingerprint string // Current flake fingerprint, updated by metadata fetch.
+	hostList         hostListModel
+	hosts            map[string]*hostModel
+	selectedHost     *hostModel
+	hoverTimerID     uint64 // Unique ID for each host hover timer.
+	nixPool          *npool.Pool
+	contentPanel     *viewport.Model
+	sizes            layoutSizes
+	keys             config.KeyMap
+	help             help.Model
+	spinner          spinner.Model
+	jumpToLetter     bool
+	confirmation     *confirmationMsg
+	commandPalette   *CommandPalette
+	inputOverlay     *InputOverlay
+	textDialog       *ScrollableDialog
+	error            string
+	flashText        string
+	flashTimer       *time.Timer
+	cmdHistory       []string
 }
 
 type sshCheckState int
@@ -743,6 +744,7 @@ func (m *Model) fetchFlakeMetadataCmd() tea.Cmd {
 }
 
 func (m *Model) handleFlakeMetadataMsg(msg flakeMetadataMsg) tea.Cmd {
+	m.flakeFingerprint = msg.meta.Fingerprint
 	if err := m.db.StoreFlakeVersion(msg.meta); err != nil {
 		slog.Error("Failed to store flake version", "err", err)
 	}
@@ -1054,6 +1056,11 @@ func errorFlashCmd(format string, a ...any) tea.Cmd {
 func (m *Model) commands() []Command {
 	return []Command{
 		{
+			Name:        "deployments",
+			Description: "List deployment history for selected host",
+			Execute:     (*Model).cmdListDeployments,
+		},
+		{
 			Name:        "fingerprints",
 			Description: "List stored flake fingerprints",
 			Execute:     (*Model).cmdListFingerprints,
@@ -1063,6 +1070,44 @@ func (m *Model) commands() []Command {
 			Description: "List configured hosts",
 			Execute:     (*Model).cmdListHosts,
 		},
+	}
+}
+
+func (m *Model) cmdListDeployments() tea.Cmd {
+	host := m.selectedHost
+	if host == nil {
+		return func() tea.Msg {
+			return textDisplayMsg{text: "No host selected."}
+		}
+	}
+	hostName := host.name
+
+	return func() tea.Msg {
+		records, err := m.db.ListDeployments(hostName)
+		if err != nil {
+			slog.Error("Failed to list deployments", "err", err, "host", hostName)
+			return criticalErrorMsg{detail: "Failed to list deployments: " + err.Error()}
+		}
+
+		if len(records) == 0 {
+			return textDisplayMsg{text: fmt.Sprintf("No deployment history for %q.", hostName)}
+		}
+
+		var b strings.Builder
+		fmt.Fprintf(&b, "Deployment History for %q\n\n", hostName)
+
+		for _, r := range records {
+			status := renderedStatusFailed
+			if r.Success {
+				status = renderedStatusSuccess
+			}
+			fmt.Fprintf(&b, "  %s %s  %s\n",
+				subtleStyle.Render(r.Timestamp.Format(time.DateTime)),
+				status,
+				shortFingerprint(r.Fingerprint))
+		}
+
+		return textDisplayMsg{text: b.String()}
 	}
 }
 
@@ -1141,6 +1186,14 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 	border.Bottom = middle
 	border.BottomRight = right
 	return border
+}
+
+// shortFingerprint returns the first 12 chars of a fingerprint for display.
+func shortFingerprint(fp string) string {
+	if len(fp) > 12 {
+		return fp[:12]
+	}
+	return fp
 }
 
 func tabSuffixBorder() lipgloss.Border {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -231,6 +231,7 @@ func (m Model) Init() tea.Cmd {
 		m.hostList.Init(),
 		m.spinner.Tick,
 		m.fetchFlakeMetadataCmd(),
+		m.fetchAllHostsBehindCmd(),
 	)
 }
 
@@ -748,9 +749,12 @@ func (m *Model) handleFlakeMetadataMsg(msg flakeMetadataMsg) tea.Cmd {
 	if err := m.db.StoreFlakeVersion(msg.meta); err != nil {
 		slog.Error("Failed to store flake version", "err", err)
 	}
-	return tea.Tick(time.Minute, func(time.Time) tea.Msg {
-		return flakeMetadataTickMsg{}
-	})
+	return tea.Batch(
+		tea.Tick(time.Minute, func(time.Time) tea.Msg {
+			return flakeMetadataTickMsg{}
+		}),
+		m.fetchAllHostsBehindCmd(),
+	)
 }
 
 func (m *Model) handleOpenPagerMsg(_ openPagerMsg) tea.Cmd {
@@ -1185,6 +1189,31 @@ func (m *Model) addToCmdHistory(cmd string) {
 	m.cmdHistory = append(m.cmdHistory, cmd)
 	if len(m.cmdHistory) > maxCmdHistory {
 		m.cmdHistory = m.cmdHistory[len(m.cmdHistory)-maxCmdHistory:]
+	}
+}
+
+// fetchAllHostsBehindCmd returns a command that computes how many clean commits
+// behind the latest each host's most recent deployment is.
+func (m *Model) fetchAllHostsBehindCmd() tea.Cmd {
+	hostNames := make([]string, 0, len(m.hosts))
+	for name := range m.hosts {
+		hostNames = append(hostNames, name)
+	}
+	db := m.db
+
+	return func() tea.Msg {
+		storeInfo, err := db.HostsCommitsBehind(hostNames)
+		if err != nil {
+			slog.Error("Failed to compute hosts commits behind", "err", err)
+			return nil
+		}
+
+		counts := make(map[string]behindInfo, len(storeInfo))
+		for name, si := range storeInfo {
+			counts[name] = behindInfo{behind: si.Behind, dirty: si.Dirty}
+		}
+
+		return hostsBehindMsg{counts: counts}
 	}
 }
 


### PR DESCRIPTION
Record each deployment (timestamp, flake fingerprint, success/failure) per
host in BoltDB. A new 'deployments' command palette entry displays the
history for the selected host.

- Add deploy-history bucket and DeploymentRecord type to store
- Record deployments on deploy completion in host_deploy.go
- Track current flake fingerprint in UI Model
- Add ListDeployments, LatestDeployment, RecordDeployment store methods
- Add store tests for deployment history and existing functionality

I'll hold off on merging this until I've figured out how I want to decorate out-of-date hosts in the UI, just in case the storage schema needs to change.
